### PR TITLE
POSUI-68

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/MainActivity.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/MainActivity.java
@@ -28,4 +28,10 @@ public class MainActivity extends AppCompatActivity {
             e.printStackTrace();
         }
     }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        finish();
+    }
 }


### PR DESCRIPTION
POSUI-68
POSLink UI causes app return to Custom UI version screen instead of the BroadPOS application for first transaction