### PR TITLE
[POSUI-57] Unable to use hard key OK (green button) to confirm the in…

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/AVSFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/AVSFragment.java
@@ -101,6 +101,12 @@ public class AVSFragment extends BaseEntryFragment {
     protected void onConfirmButtonClicked(){
         String addr = editTextAddr.getText().toString();
         String zip = editTextZip.getText().toString();
+
+        if(editTextAddr.hasFocus()) {
+            (getActivity().findViewById(editTextAddr.getNextFocusDownId())).requestFocusFromTouch();
+            return;
+        }
+
         EntryRequestUtils.sendNextAVS(requireContext(), packageName, action, addr, zip);
     }
 }


### PR DESCRIPTION
 Unable to use hard key OK (green button) to confirm the input/selection when POSLinkUI installed

Modified AVS