### PR TITLE
[POSUI-75] NFC LOGO block should not visible in EBT/GIFT/Credit Force transaction

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/InputAccountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/InputAccountFragment.java
@@ -352,6 +352,8 @@ public class InputAccountFragment extends BaseEntryFragment {
         apple.setVisibility(supportApplePay ? View.VISIBLE : View.GONE);
         google.setVisibility(supportGooglePay ? View.VISIBLE : View.GONE);
         samsung.setVisibility(supportSamsungPay ? View.VISIBLE : View.GONE);
+        rootView.findViewById(R.id.contactless_logo_container)
+                .setVisibility((supportNFC || supportApplePay || supportGooglePay || supportSamsungPay) ? View.VISIBLE : View.GONE);
 
         receiver = new InputAccountFragment.Receiver();
         IntentFilter intentFilter = new IntentFilter();

--- a/app/src/main/res/layout-land/fragment_input_account.xml
+++ b/app/src/main/res/layout-land/fragment_input_account.xml
@@ -118,6 +118,7 @@
             android:scaleType="fitCenter"/>
 
         <LinearLayout
+            android:id="@+id/contactless_logo_container"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="2"

--- a/app/src/main/res/layout/fragment_input_account.xml
+++ b/app/src/main/res/layout/fragment_input_account.xml
@@ -106,6 +106,7 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/contactless_logo_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:orientation="horizontal"


### PR DESCRIPTION
[POSUI-75] NFC LOGO block should not visible in EBT/GIFT/Credit Force transaction

Block will be visible if there is at least one nfc logo

[POSUI-75]: https://pax-us.atlassian.net/browse/POSUI-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ