### PR TITLE
[POSUI-79] Android Alphabet Keyboard shows up when terminal displays any transaction status message to user during standalone mode of operation with POSLink UI

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/BaseEntryFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/BaseEntryFragment.java
@@ -150,7 +150,7 @@ public abstract class BaseEntryFragment extends Fragment {
         });
         ((Activity)(editTexts[0].getContext())).getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE|WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
         InputMethodManager inputMethodManager = (InputMethodManager)(((Activity)(editTexts[0].getContext())).getSystemService(Context.INPUT_METHOD_SERVICE));
-        inputMethodManager.showSoftInput(editTexts[0], InputMethodManager.SHOW_FORCED);
+        inputMethodManager.showSoftInput(editTexts[0], InputMethodManager.SHOW_IMPLICIT);
         editTexts[0].requestFocus();
     }
 

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/EntryActivity.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/EntryActivity.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -157,6 +158,8 @@ public class EntryActivity extends AppCompatActivity{
         if(!TextUtils.isEmpty(dialogTag)) {
             DialogFragment dialogFragment = UIFragmentHelper.createStatusDialogFragment(intent);
             if (dialogFragment != null) {
+                InputMethodManager inputMethodManager = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
+                inputMethodManager.hideSoftInputFromWindow(getWindow().getDecorView().getWindowToken(), InputMethodManager.HIDE_IMPLICIT_ONLY);
                 UIFragmentHelper.showDialog(getSupportFragmentManager(), dialogFragment, dialogTag);
             } else {
                 UIFragmentHelper.closeDialog(getSupportFragmentManager(),dialogTag);

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
@@ -257,7 +257,7 @@ public class TipFragment extends BaseEntryFragment {
                     notifyDataSetChanged();
 
                     ((InputMethodManager)getActivity().getSystemService(Context.INPUT_METHOD_SERVICE))
-                            .hideSoftInputFromWindow(editText.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+                            .hideSoftInputFromWindow(editText.getWindowToken(), InputMethodManager.HIDE_IMPLICIT_ONLY);
                 }
             });
 


### PR DESCRIPTION
Android Alphabet Keyboard shows up when terminal displays any transaction status message to user during standalone mode of operation with POSLink UI