### PR TITLE
[BPOSANDJAX-737] [POSLink UI] Sale transaction gets stuck in the signature screen after the signature is submitted

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/BaseEntryFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/BaseEntryFragment.java
@@ -24,6 +24,7 @@ import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.pax.us.pay.ui.constant.entry.EntryResponse;
+import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.event.ResponseEvent;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
@@ -133,6 +134,9 @@ public abstract class BaseEntryFragment extends Fragment {
         Logger.i("receive Entry Response ACTION_ACCEPTED for action \"" + getEntryAction() + "\"");
         //3.2 when got accepted, should not response AbortEvent any more.
         deactivate();
+        getParentFragmentManager().beginTransaction()
+                .setCustomAnimations(R.anim.enter_from_right, R.anim.exit_to_left)
+                .remove(this).commit();
     }
 
     /**

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/InputAccountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/InputAccountFragment.java
@@ -197,7 +197,11 @@ public class InputAccountFragment extends BaseEntryFragment {
     public void onDestroy() {
         super.onDestroy();
         if (receiver != null) {
-            requireContext().unregisterReceiver(receiver);
+            try{
+                requireContext().unregisterReceiver(receiver);
+            } catch (Exception e){
+                Logger.e(e);
+            }
         }
     }
 

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/PINFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/PINFragment.java
@@ -82,8 +82,11 @@ public class PINFragment extends BaseEntryFragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
-
-        requireContext().unregisterReceiver(receiver);
+        try{
+            requireContext().unregisterReceiver(receiver);
+        } catch (Exception e){
+            Logger.e(e);
+        }
     }
     
     @Override

--- a/app/src/main/res/anim/enter_from_right.xml
+++ b/app/src/main/res/anim/enter_from_right.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+    <translate
+        android:fromXDelta="100%p" android:toXDelta="0%"
+        android:fromYDelta="0%" android:toYDelta="0%"
+        android:duration="50" />
+</set>

--- a/app/src/main/res/anim/exit_to_left.xml
+++ b/app/src/main/res/anim/exit_to_left.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+    <translate
+        android:fromXDelta="0%" android:toXDelta="-100%p"
+        android:fromYDelta="0%" android:toYDelta="0%"
+        android:duration="50"/>
+</set>


### PR DESCRIPTION
Closing fragments on entry acceptation. SignatureFragment won't be on top in such case.