### PR TITLE
Action Bar has gap in small screen landscape devices

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/utils/EntryActivityActionBar.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/utils/EntryActivityActionBar.java
@@ -31,7 +31,7 @@ public class EntryActivityActionBar {
         actionBar.setDisplayShowTitleEnabled(false);
 
         ConstraintLayout actionBarView = (ConstraintLayout) activityContext.getLayoutInflater().inflate(R.layout.action_bar, null);
-        actionBar.setCustomView(actionBarView, new ActionBar.LayoutParams(MATCH_PARENT, (int) activityContext.getResources().getDimension(R.dimen.toolbar_height)));
+        actionBar.setCustomView(actionBarView, new ActionBar.LayoutParams(MATCH_PARENT, MATCH_PARENT));
 
         ((ViewGroup)actionBar.getCustomView().getParent()).setPadding(0,0,0,0);
     }


### PR DESCRIPTION
Current:
![image](https://github.com/PAXTechnologyInc/POSLinkUI-Demo/assets/106608036/30d9549e-6983-4218-b1cb-90e1b224284c)


After Change:
![image](https://github.com/PAXTechnologyInc/POSLinkUI-Demo/assets/106608036/273f0524-9bbc-4d67-ad2b-3f2fa93fc7ea)
