### PR TITLE
POSUI-227 After printing, the idle screen should not be exposed, and the Please Enter Amount screen should not appear before showing transaction result.

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/EntryActivity.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/EntryActivity.java
@@ -138,7 +138,8 @@ public class EntryActivity extends AppCompatActivity{
             .setReorderingAllowed(true)
             .setCustomAnimations(R.anim.anim_enter_from_bottom, R.anim.anim_exit_to_bottom)
             .remove(Objects.requireNonNull(getSupportFragmentManager().findFragmentById(R.id.status_container)))
-            .commit();
+            .commitAllowingStateLoss(); // POSUI-243
+
     }
 
     private boolean isStatusPresent() {
@@ -146,7 +147,10 @@ public class EntryActivity extends AppCompatActivity{
     }
 
     public void loadStatus(Intent intent) {
-        @NonNull StatusFragment statusFragment = InformationStatus.TRANS_COMPLETED.equals(intent.getAction()) ? new TransCompletedStatusFragment(intent, this) : new StatusFragment(intent, this);
+        @NonNull
+        StatusFragment statusFragment = InformationStatus.TRANS_COMPLETED.equals(intent.getAction())
+                ? new TransCompletedStatusFragment(intent, this)
+                : new StatusFragment(intent, this);
         getSupportFragmentManager().executePendingTransactions();
 
         if(statusFragment.isConclusive()){

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/status/StatusFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/status/StatusFragment.java
@@ -33,6 +33,11 @@ public class StatusFragment extends Fragment {
 
     public static final long DURATION_DEFAULT = 5000, DURATION_SHORT = 1000;
 
+    // Default constructor
+    public StatusFragment() {
+        // Default initialization code here
+    }
+
     public StatusFragment(Intent intent, Context context) {
         this.intent = intent;
         Bundle bundle = new Bundle();
@@ -172,7 +177,7 @@ public class StatusFragment extends Fragment {
                 break;
             }
             default:
-                Logger.e("Unknown status action:" + action);
+                Logger.i("Status action: " + action);
                 break;
         }
 


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-227

### Related Pull Requests  
*

### How do you fix?  
Replaced commit().

### Test Evidence
Run visa credit card for transaction.
Check ticket comment.