### PR TITLE
[POSUI-247] [Rapid Connect] Confirm button is disabled if the CVV value is cleared after input

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ASecurityFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ASecurityFragment.java
@@ -174,11 +174,6 @@ public abstract class ASecurityFragment extends BaseEntryFragment {
                     break;
             }
 
-            //3.Update confirm button status
-            if(confirmButton!=null) {
-                confirmButton.setEnabled(secureLength > 0);
-            }
-
         }
     }
 }


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-247

### Related Pull Requests  

### How do you fix?  
Removed the dependency of secure-input-length on the Confirm button.
This dependency is kept in InputAccountFragment for demonstration of SecurityStatus broadcasts.

### Test Evidence
