### PR TITLE
[POSUI-244] BroadPOS payment app's security keyboard is covering the POSUI apps toast error message for incorrect password entry

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/BaseEntryFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/BaseEntryFragment.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.graphics.Rect;
 import android.os.Bundle;
+import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -30,6 +31,7 @@ import com.pax.us.pay.ui.constant.entry.EntryResponse;
 import com.paxus.pay.poslinkui.demo.utils.DeviceUtils;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
+import com.paxus.pay.poslinkui.demo.utils.ToastUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +51,7 @@ import java.util.List;
 public abstract class BaseEntryFragment extends Fragment {
 
     private boolean active = false;
-
+    private Context appContext = getActivity();
     private String senderPackage, action;
     protected EditText[] focusableEditTexts = null;
 
@@ -197,9 +199,11 @@ public abstract class BaseEntryFragment extends Fragment {
      * @param errCode    Error Code
      * @param errMessage Error Message
      */
-    protected void onEntryDeclined(long errCode, String errMessage) {
+    protected void onEntryDeclined(int errCode, String errMessage) {
         Logger.i("Receive Response Broadcast ACTION_DECLINED for action \"" + action + "\" (" + errCode + "-" + errMessage + ")");
-        Toast.makeText(requireActivity(), errMessage, Toast.LENGTH_SHORT).show();
+        // POSUI-244
+        Toast toast = Toast.makeText(requireActivity(), errMessage, Toast.LENGTH_SHORT);
+        ToastUtils.adjustToastPosition(toast);
     }
 
     /**
@@ -243,7 +247,7 @@ public abstract class BaseEntryFragment extends Fragment {
                 break;
             case EntryResponse.ACTION_DECLINED:
                 EditabilityBlocker.getInstance().release();
-                onEntryDeclined(result.getLong(EntryResponse.PARAM_CODE), result.getString(EntryResponse.PARAM_MSG));
+                onEntryDeclined(result.getInt(EntryResponse.PARAM_CODE), result.getString(EntryResponse.PARAM_MSG)); //POSUI-244
                 break;
         }
     };

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fleet/FleetFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fleet/FleetFragment.java
@@ -138,7 +138,7 @@ public class FleetFragment extends BaseEntryFragment {
     }
 
     @Override
-    protected void onEntryDeclined(long errCode, String errMessage) {
+    protected void onEntryDeclined(int errCode, String errMessage) {
         super.onEntryDeclined(errCode, errMessage);
 
         //re enter if next request declined

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fsa/FSAFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fsa/FSAFragment.java
@@ -209,7 +209,7 @@ public class FSAFragment extends BaseEntryFragment {
     }
 
     @Override
-    protected void onEntryDeclined(long errCode, String errMessage) {
+    protected void onEntryDeclined(int errCode, String errMessage) {
         super.onEntryDeclined(errCode, errMessage);
 
         //Re enter sub health care amount

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/utils/ToastUtils.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/utils/ToastUtils.java
@@ -1,0 +1,35 @@
+package com.paxus.pay.poslinkui.demo.utils;
+
+import android.view.Gravity;
+import android.widget.Toast;
+
+/**
+ * deng.xiong@pax.us 1/10/2024
+ * <p>
+ *     ACTION_DECLINED
+ * </p>
+
+ */
+public class ToastUtils {
+
+    public final static int Y_OFFSET = 100; // Customized
+
+    public static int getScreenWidth() {
+        // Could use the screen width/2 if required
+
+        return 0; // Return 0 as default
+    }
+
+    public static void adjustToastPosition(Toast toast) {
+        toast.setGravity(Gravity.CENTER_VERTICAL, 0,  getScreenWidth() - Y_OFFSET);
+        toast.show();
+    }
+
+    public static void resetToastPosition(Toast toast) {
+        toast.setGravity(Gravity.CENTER_VERTICAL, 0, 0);
+        toast.show();
+    }
+
+
+}
+


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-244

### Related Pull Requests  
*

### How do you fix?  
1. Fixed the type error.
2. Adjusted the toast location.

### Test Evidence
Confirmed with Reyhan:
![image](https://github.com/PAXTechnologyInc/POSLinkUI-Demo/assets/123973756/1f2e54df-f475-42e9-be10-dbcbb0ca435b)
Updated:
![image](https://github.com/PAXTechnologyInc/POSLinkUI-Demo/assets/123973756/a7ea0237-f843-4031-b2c1-47eca675e1f4)
![image](https://github.com/PAXTechnologyInc/POSLinkUI-Demo/assets/123973756/56213a15-e93b-4239-8180-a44cb87b4f5d)
![image](https://github.com/PAXTechnologyInc/POSLinkUI-Demo/assets/123973756/14631a3c-59db-4b84-b858-aa846cda2338)
