### PR TITLE
[POSUI-248] The processing screen flash back to previously displayed screens before transitioning to next UI

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/POSLinkStatusManager.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/POSLinkStatusManager.java
@@ -37,7 +37,7 @@ public class POSLinkStatusManager extends BroadcastReceiver implements Lifecycle
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        Logger.d("Receiving Status Broadcast " + intent.getAction());
+        Logger.intent(intent, "STATUS BROADCAST:\t" + intent.getAction());
         if (handlerMap.containsKey(intent.getAction())) {
             handlerMap.get(intent.getAction()).run();
         }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ASecurityFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ASecurityFragment.java
@@ -125,7 +125,7 @@ public abstract class ASecurityFragment extends BaseEntryFragment {
 
         @Override
         public void onReceive(Context context, Intent intent) {
-            Logger.i("receive Status Action \""+intent.getAction()+"\"");
+            Logger.intent(intent, "STATUS BROADCAST:\t" + intent.getAction());
             switch (intent.getAction()) {
                 case SecurityStatus.SECURITY_ENTER_CLEARED:{
                     secureLength = 0;

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ClssLightsViewStatusManager.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ClssLightsViewStatusManager.java
@@ -13,6 +13,7 @@ import androidx.lifecycle.LifecycleOwner;
 
 import com.pax.us.pay.ui.constant.status.CardStatus;
 import com.pax.us.pay.ui.constant.status.ClssLightStatus;
+import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.view.ClssLightsView;
 
 public class ClssLightsViewStatusManager extends BroadcastReceiver implements LifecycleEventObserver {
@@ -31,7 +32,7 @@ public class ClssLightsViewStatusManager extends BroadcastReceiver implements Li
     public void onReceive(Context context, Intent intent) {
         if(clssLightsView == null) return;
         if(!isActive) return;
-
+        Logger.intent(intent, "STATUS BROADCAST:\t" + intent.getAction());
         clssLightsView.updateStatus(intent.getAction());
     }
 

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/InputAccountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/InputAccountFragment.java
@@ -293,7 +293,7 @@ public class InputAccountFragment extends BaseEntryFragment {
 
         @Override
         public void onReceive(Context context, Intent intent) {
-            Logger.i("receive Status Action \"" + intent.getAction() + "\"");
+            Logger.intent(intent, "STATUS BROADCAST:\t" + intent.getAction());
             switch (intent.getAction()) {
                 case InformationStatus.TRANS_AMOUNT_CHANGED_IN_CARD_PROCESSING:
                     //4.Update amount

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ManageInputAccountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ManageInputAccountFragment.java
@@ -284,7 +284,7 @@ public class ManageInputAccountFragment extends BaseEntryFragment {
 
         @Override
         public void onReceive(Context context, Intent intent) {
-            Logger.i("receive Status Action \"" + intent.getAction() + "\"");
+            Logger.intent(intent, "STATUS BROADCAST:\t" + intent.getAction());
             switch (intent.getAction()) {
                 case CardStatus.CARD_INSERT_REQUIRED:
                 case CardStatus.CARD_TAP_REQUIRED:

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/PINFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/PINFragment.java
@@ -183,7 +183,7 @@ public class PINFragment extends BaseEntryFragment {
 
         @Override
         public void onReceive(Context context, Intent intent) {
-            Logger.i("receive Status Action \""+intent.getAction()+"\"");
+            Logger.intent(intent, "STATUS BROADCAST:\t" + intent.getAction());
             String text = pinBox.getText().toString();
 
             switch (intent.getAction()) {

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/utils/Logger.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/utils/Logger.java
@@ -71,8 +71,16 @@ public final class Logger {
     }
 
 
-    public static void intent(Intent intent) {
+    public static void intent(Intent intent, String... headings) {
         StringBuilder intentBuilder = new StringBuilder();
+
+        if(headings != null){
+            for(String heading : headings){
+                intentBuilder.append(heading).append(System.lineSeparator());
+            }
+        }
+
+        intentBuilder.append("Intent: ").append(intent.getAction()).append(System.lineSeparator());
         if(intent.getExtras() != null){
             for(String key : intent.getExtras().keySet()){
                 intentBuilder.append(key).append(": ");

--- a/app/src/main/res/anim/anim_enter_from_right.xml
+++ b/app/src/main/res/anim/anim_enter_from_right.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:interpolator="@android:anim/decelerate_interpolator"
+        android:duration="150"
+        android:fromXDelta="100%"
+        android:toXDelta="0%" />
+    <alpha
+        android:interpolator="@android:anim/anticipate_overshoot_interpolator"
+        android:duration="80"
+        android:startOffset="50"
+        android:fromAlpha="0"
+        android:toAlpha="1"
+        />
+</set>

--- a/app/src/main/res/anim/anim_exit_to_left.xml
+++ b/app/src/main/res/anim/anim_exit_to_left.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:interpolator="@android:anim/decelerate_interpolator"
+        android:duration="150"
+        android:fromXDelta="0%"
+        android:toXDelta="-100%" />
+    <alpha
+        android:interpolator="@android:anim/anticipate_overshoot_interpolator"
+        android:duration="100"
+        android:fromAlpha="1"
+        android:toAlpha="0"
+        />
+</set>

--- a/app/src/main/res/layout/activity_entry.xml
+++ b/app/src/main/res/layout/activity_entry.xml
@@ -29,23 +29,6 @@
             />
     </LinearLayout>
 
-    <View
-        android:id="@+id/entry_dark_overlap"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-
-        android:background="@color/pastel_background"
-        android:alpha="0.4"
-        android:visibility="invisible"
-
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintVertical_chainStyle="spread"
-        app:layout_constraintVertical_bias="1"
-        />
-
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/status_container"
         android:layout_width="0dp"


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-248

### Related Pull Requests  

### How do you fix?  
Removed EntryFragment upon receiving ACTION_ACCEPTED.

### Test Evidence
https://github.com/PAXTechnologyInc/POSLinkUI-Demo/assets/106608036/8e88eb05-2d1f-43ee-83fb-a6c11126373e
