### PR TITLE
BPOSANDJAX-1283 [POSLink UI] App does not support CLEAR_MESSAGE POSLink status broadcast

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
@@ -47,7 +47,12 @@ public class ShowMessageFragment extends BaseEntryFragment {
         posLinkStatusManager.registerHandler(POSLinkStatus.CLEAR_MESSAGE, this::clearMessage);
     }
 
+    private void clearTitle() {
+        title = null;
+    }
+
     private void clearMessage() {
+        clearTitle(); // BPOSANDJAX-1283
         messages.clear();
         loadView(getView());
     }


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/BPOSANDJAX-1283

### Related Pull Requests  
*https://github.com/PAXTechnologyInc/POSLink-UI/pull/99

### How do you fix?  
Added clearTitle.

### Test Evidence
Refer to FDRC: title message will be deleted in CLEAR_MESSAGE
Tested on Portico and TransIT