### PR TITLE
[POSUI-296] [Paragon] The “Tax” and “Total” titles do not display when executing the SHOWITEM command with POSLinkUI installed

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowItemFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowItemFragment.java
@@ -1,6 +1,7 @@
 package com.paxus.pay.poslinkui.demo.entry.poslink;
 
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -79,7 +80,25 @@ public class ShowItemFragment extends BaseEntryFragment {
         LinearLayout titleLayout = rootView.findViewById(R.id.tv_title_show_item);
         TextView tvTotalLineShowItem = rootView.findViewById(R.id.tv_total_line_show_item);
         TextView tvTaxLineShowItem = rootView.findViewById(R.id.tv_tax_line_show_item);
+        TextView tvTotalLineTitle = rootView.findViewById(R.id.total_line_title);
+        TextView tvTaxLineTitle = rootView.findViewById(R.id.tax_line_title);
         RecyclerView recyclerViewShowItem = rootView.findViewById(R.id.recycler_View_show_item);
+
+        if (!TextUtils.isEmpty(taxLine)) {
+            tvTaxLineTitle.setVisibility(View.VISIBLE);
+            tvTaxLineShowItem.setVisibility(View.VISIBLE);
+        } else {
+            tvTaxLineTitle.setVisibility(View.GONE);
+            tvTaxLineShowItem.setVisibility(View.GONE);
+        }
+
+        if (!TextUtils.isEmpty(totalLine)) {
+            tvTotalLineTitle.setVisibility(View.VISIBLE);
+            tvTotalLineShowItem.setVisibility(View.VISIBLE);
+        } else {
+            tvTotalLineTitle.setVisibility(View.GONE);
+            tvTotalLineShowItem.setVisibility(View.GONE);
+        }
 
         if (title == null || title.isEmpty()) {
             titleLayout.setVisibility(View.GONE);

--- a/app/src/main/res/layout/fragment_show_item.xml
+++ b/app/src/main/res/layout/fragment_show_item.xml
@@ -73,6 +73,7 @@
             android:visibility="gone"/>
 
         <TextView
+            android:id="@+id/tax_line_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-296

### How do you fix?  
Set taxTitle and TotalTitle as `visible` if `taxLine` and `totalLine` are available.

### Test Evidence

https://github.com/user-attachments/assets/8ebd984c-3d0d-44d1-a4fd-17b466730a78

