### PR TITLE
[POSUI-284] POSLink UI Demo sending the same EntryRequest.ACTION_NEXT broadcast irrespective of whether the 'Confirm' or 'No Tip' button is selected

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
@@ -164,7 +164,7 @@ public class TipFragment extends BaseEntryFragment {
         SelectOptionsView noTipOptionView = rootView.findViewById(R.id.select_view_no_tip);
         if(isNoTipSelectionAllowed) {
             noTipOptionView.setVisibility(View.VISIBLE);
-            List<SelectOptionsView.Option> noTipOptionList = new ArrayList<>(Arrays.asList(new SelectOptionsView.Option(null, "No Tip", null, 0L)));
+            List<SelectOptionsView.Option> noTipOptionList = new ArrayList<>(Arrays.asList(new SelectOptionsView.Option(null, "No Tip", null, -1L)));
             noTipOptionView.initialize(getActivity(), 1, noTipOptionList, option -> {
                 tip = (long) option.getValue();
                 onConfirmButtonClicked();
@@ -230,7 +230,7 @@ public class TipFragment extends BaseEntryFragment {
 
     private void submit(long value) {
         Bundle bundle = new Bundle();
-        bundle.putLong(EntryRequest.PARAM_TIP, value);
+        if(value>=0) bundle.putLong(EntryRequest.PARAM_TIP, value);
         sendNext(bundle);
     }
 }


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-284

### Related Pull Requests  


### How do you fix?  
Do NOT submit PARAM_TIP if "No Tip" is selected.

### Test Evidence

https://github.com/user-attachments/assets/9a1b73d3-87b5-42c1-9211-d065d25e7596

![image](https://github.com/user-attachments/assets/c38217ba-8626-490f-b0d2-27e912df0832)
