### PR TITLE
[POSUI-294] [Paragon] The Tax and Total lines are not cleared when executing the CLEARMESSAGE command with POSLinkUI installed

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
@@ -51,8 +51,14 @@ public class ShowMessageFragment extends BaseEntryFragment {
         title = null;
     }
 
+    private void clearTaxandTotal() {
+        tax = null;
+        total = null;
+    }
+
     private void clearMessage() {
         clearTitle(); // BPOSANDJAX-1283
+        clearTaxandTotal(); // POSUI-294
         messages.clear();
         loadView(getView());
     }


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-294

### Related Pull Requests  
*

### How do you fix?  
Add logic to reset the Tax and Total lines fields

### Test Evidence
