### PR TITLE
[POSUI-300] [Portico Canada] POSLinkUI Demo V1.01.00_20240226 Crashedwhen sending a SHOWMESSAGE POSLink Command with both Tax Line and Total Line having Values

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
@@ -74,6 +74,9 @@ public class ShowMessageFragment extends BaseEntryFragment {
         if(messageList != null) {
             messages = parseMessageList(messageList);
         }
+        else {
+            messages = new ArrayList<>();  // POSUI-300
+        }
     }
 
     @Override


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-300

### Related Pull Requests  
*

### How do you fix?  
Prevent the crash by temporarily allowing message object to be empty

### Test Evidence
