### PR TITLE
[POSUI-284] POSLink UI Demo sending the same EntryRequest.ACTION_NEXT broadcast irrespective of whether the 'Confirm' or 'No Tip' button is selected

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
@@ -151,15 +151,6 @@ public class TipFragment extends BaseEntryFragment {
             focusableEditTexts = new EditText[]{tipInputEditText};
         }
 
-        //Enter Tip or Enter Other Tip
-        tipInputEditText.addTextChangedListener(new AmountTextWatcher(maxLength, currency){
-            @Override public void afterTextChanged(Editable s) {
-                super.afterTextChanged(s);
-                tip = CurrencyUtils.parse(s.toString());
-            }
-        });
-        tipInputEditText.setText("0"); // Initializing TextChangedListener
-
         //No Tip Option
         SelectOptionsView noTipOptionView = rootView.findViewById(R.id.select_view_no_tip);
         if(isNoTipSelectionAllowed) {
@@ -171,6 +162,15 @@ public class TipFragment extends BaseEntryFragment {
             });
             if(isSelectTipEnabled) tipOptionsView.append(noTipOptionView);
         }
+
+        //Enter Tip or Enter Other Tip
+        tipInputEditText.addTextChangedListener(new AmountTextWatcher(maxLength, currency){
+            @Override public void afterTextChanged(Editable s) {
+                super.afterTextChanged(s);
+                tip = CurrencyUtils.parse(s.toString());
+            }
+        });
+        tipInputEditText.setText(String.valueOf(tip)); //Initialize TextWatcher with Default Tip Value
 
         //Confirm
         Button confirmButton = rootView.findViewById(R.id.button_confirm);
@@ -230,7 +230,11 @@ public class TipFragment extends BaseEntryFragment {
 
     private void submit(long value) {
         Bundle bundle = new Bundle();
-        if(value>=0) bundle.putLong(EntryRequest.PARAM_TIP, value);
+
+        if(value>=0) {
+            bundle.putLong(EntryRequest.PARAM_TIP, value);
+        }
+
         sendNext(bundle);
     }
 }


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-284

### Related Pull Requests  


### How do you fix?  
Do not submit PARAM_TIP if end user does not explicitly set the tip.

### Test Evidence

**Transaction 1:** Press "No Tip"
**Transaction 2:** Press "Confirm" without inputting anything
**Transaction 3:** Press "Confirm" after setting "0"

Transaction 2 and 3 are marked as Untipped.
![image](https://github.com/user-attachments/assets/02417591-225c-4d3c-b6ef-bd743c2df4ff)
