### PR TITLE
[POSUI-290] POSLINK UI shows items in the same layout when running SHOWITEM command with set Topdown = Y/ N

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ItemListAdapter.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ItemListAdapter.java
@@ -62,7 +62,7 @@ public class ItemListAdapter extends RecyclerView.Adapter<ItemListAdapter.ItemVi
                 quantityDesc = itemDetail.getQuantity() + "ft";
                 break;
         }
-        holder.tvProductName.setText((position + 1) + "." + itemDetail.getProductName());
+        holder.tvProductName.setText((position + 1) + ". " + itemDetail.getProductName());
 
         RelativeLayout.LayoutParams productNameLps = (RelativeLayout.LayoutParams)holder.tvProductName.getLayoutParams();
         if (!TextUtils.isEmpty(itemDetail.getQuantity())) {

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowItemFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowItemFragment.java
@@ -121,9 +121,9 @@ public class ShowItemFragment extends BaseEntryFragment {
         recyclerViewShowItem.addItemDecoration(new DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL));
 
         if (itemWrapperList != null) {
-            itemListAdapter = new ItemListAdapter(requireContext(), topDown ? itemWrapperList : reverseList(itemWrapperList), currencySymbol);
+            itemListAdapter = new ItemListAdapter(requireContext(), itemWrapperList, currencySymbol);
             recyclerViewShowItem.setAdapter(itemListAdapter);
-            recyclerViewShowItem.scrollToPosition(topDown ? itemWrapperList.size() - 1 : 0);
+            recyclerViewShowItem.scrollToPosition(topDown ? 0 : itemWrapperList.size() - 1);
         }
 
         ConstraintLayout.LayoutParams recyclerViewLayoutParams = (ConstraintLayout.LayoutParams) recyclerViewShowItem.getLayoutParams();


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-290

### Related Pull Requests  

### How do you fix?  

### Test Evidence
TOP_DOWN=Y
![image](https://github.com/user-attachments/assets/5c2e5efb-c99d-4568-ae25-40f2c1dfe742)

TOP_DOWN=N
![image](https://github.com/user-attachments/assets/97d6ab80-d650-4593-87ba-67de00adc872)
