### PR TITLE
[POSUI-313] [Aries8] Soft keyboard does not prompt after clicking on the text field for Enter Fuel Amount Page and Enter Zip Code Pages when running Credit Auth with fleet card [POSUI-315] [Aries8] Virtual keyboard does not appear for entering Voucher Auth Code [POSUI-317] [Shift4 Lite] [Test] With UI Demo installed, Product Description Prompt does not show the Alphanumeric Keyboard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
 }
 
 def releaseTime() {
@@ -9,7 +10,7 @@ def VERSION_NAME = "V1.02.00_" + releaseTime()
 def ARCHIVES_BASE_NAME = "POSLinkUI-Demo_" + VERSION_NAME
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     signingConfigs {
         release {
@@ -44,6 +45,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     namespace 'com.paxus.pay.poslinkui.demo'
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 
     buildTypes {
         release {
@@ -70,6 +74,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation files('libs\\poslinkui-1.02.00.jar')
+    implementation 'androidx.core:core-ktx:1.10.1'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
             android:launchMode="singleTop"
             android:autoRemoveFromRecents="true"
             android:clearTaskOnLaunch="true"
+            android:windowSoftInputMode="adjustNothing"
             />
 
         <activity-alias android:name=".CONFIRMATION.CONFIRM_ADJUST_TIP" android:targetActivity=".entry.EntryActivity">

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/BaseEntryFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/BaseEntryFragment.java
@@ -1,8 +1,6 @@
 package com.paxus.pay.poslinkui.demo.entry;
 
-import android.app.Activity;
 import android.content.Context;
-import android.content.ContextWrapper;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.view.KeyEvent;
@@ -14,7 +12,6 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.CheckedTextView;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.LayoutRes;
@@ -26,10 +23,10 @@ import androidx.fragment.app.FragmentResultListener;
 import com.pax.us.pay.ui.constant.entry.EntryExtraData;
 import com.pax.us.pay.ui.constant.entry.EntryRequest;
 import com.pax.us.pay.ui.constant.entry.EntryResponse;
-import com.paxus.pay.poslinkui.demo.utils.DeviceUtils;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.utils.Toast;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +48,6 @@ public abstract class BaseEntryFragment extends Fragment {
     private boolean active = false;
     private Context appContext = getActivity();
     private String senderPackage, action;
-    protected EditText[] focusableEditTexts = null;
 
     @Nullable
     @Override
@@ -68,26 +64,35 @@ public abstract class BaseEntryFragment extends Fragment {
             Logger.e(this.getClass().getSimpleName() + " arguments missing!!!");
         }
 
-        focusableEditTexts = null;
 
         View view = inflater.inflate(getLayoutResourceId(), container, false);
         loadView(view);
+        setupFocusableTextFields(focusableTextFields(), view);
         activate();
         return view;
     }
 
-    @Override
-    public void onStart() {
-        super.onStart();
-        Logger.d("onStart " + getClass().getSimpleName());
-        prepareEditTextsForSubmissionWithSoftKeyboard(focusableEditTexts);
-    }
-
-    @Override
-    public void onStop() {
-        super.onStop();
-        Logger.d("onStop " + getClass().getSimpleName());
-        prepareEditTextsForSubmissionWithSoftKeyboard();
+    private void setupFocusableTextFields(TextField[] textFields, View view) {
+        if(textFields!= null && textFields.length > 0) {
+            getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+            for (int i = 0; i < textFields.length - 1; i++) {
+                textFields[i].attachToLifecycle(getViewLifecycleOwner().getLifecycle());
+                textFields[i].setImeOptions(textFields[i].getImeOptions() | EditorInfo.IME_ACTION_NEXT);
+                textFields[i].setNextFocusDownId(textFields[i + 1].getId());
+            }
+            textFields[textFields.length - 1].attachToLifecycle(getViewLifecycleOwner().getLifecycle());
+            textFields[textFields.length - 1].setImeOptions(textFields[textFields.length - 1].getImeOptions() | EditorInfo.IME_ACTION_DONE);
+            textFields[textFields.length - 1].setOnEditorActionListener((textView, i, keyEvent) -> {
+                if (i == EditorInfo.IME_ACTION_DONE) {
+                    executeEnterKeyEvent();
+                }
+                return true;
+            });
+        } else {
+            getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+            InputMethodManager imm = (InputMethodManager) requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_IMPLICIT_ONLY|InputMethodManager.HIDE_NOT_ALWAYS);
+        }
     }
 
     @Override
@@ -142,7 +147,6 @@ public abstract class BaseEntryFragment extends Fragment {
 
     protected void sendNext(Bundle bundle){
         EditabilityBlocker.getInstance().block((ViewGroup) getView());
-        prepareEditTextsForSubmissionWithSoftKeyboard();
         EntryRequestUtils.sendNext(requireContext(), senderPackage, action, bundle);
     }
 
@@ -183,6 +187,8 @@ public abstract class BaseEntryFragment extends Fragment {
         sendAbort();
     }
 
+    protected abstract TextField[] focusableTextFields();
+
     /**
      * Entry Accepted means BroadPOS accepts the output from ACTION_NEXT
      */
@@ -200,39 +206,6 @@ public abstract class BaseEntryFragment extends Fragment {
     protected void onEntryDeclined(int errCode, String errMessage) {
         Logger.i("Receive Response Broadcast ACTION_DECLINED for action \"" + action + "\" (" + errCode + "-" + errMessage + ")");
         new Toast(getActivity()).show(errMessage, Toast.TYPE.FAILURE);
-    }
-
-    /**
-     * Changes IME_ACTION of soft keyboard. All but the last EditText will focus the next one. Last one will submit.
-     */
-    private void prepareEditTextsForSubmissionWithSoftKeyboard(EditText... editTexts) {
-        if (editTexts == null || editTexts.length == 0 || !isActive()) {
-            requireActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
-            InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-            inputMethodManager.hideSoftInputFromWindow(getActivity().getWindow().getDecorView().getWindowToken(), InputMethodManager.HIDE_IMPLICIT_ONLY|InputMethodManager.HIDE_NOT_ALWAYS);
-            return;
-        }
-        for (int i = 0; i < editTexts.length - 1; i++) {
-            editTexts[i].setImeOptions(editTexts[i].getImeOptions() | EditorInfo.IME_ACTION_NEXT);
-            editTexts[i].setNextFocusDownId(editTexts[i + 1].getId());
-        }
-        editTexts[editTexts.length - 1].setImeOptions(editTexts[editTexts.length - 1].getImeOptions() | EditorInfo.IME_ACTION_DONE);
-        editTexts[editTexts.length - 1].setOnEditorActionListener((textView, i, keyEvent) -> {
-            if (i == EditorInfo.IME_ACTION_DONE) {
-                executeEnterKeyEvent();
-            }
-            return true;
-        });
-        editTexts[0].requestFocus();
-        if(!DeviceUtils.hasPhysicalKeyboard()){
-            Logger.d("Showing soft keyboard");
-            Context context = (!(editTexts[0].getContext() instanceof Activity) && editTexts[0].getContext() instanceof ContextWrapper)
-                    ? ((ContextWrapper) editTexts[0].getContext()).getBaseContext() : editTexts[0].getContext();
-            ((Activity) context).getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE| WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
-            InputMethodManager inputMethodManager = (InputMethodManager) (context.getSystemService(Context.INPUT_METHOD_SERVICE));
-            inputMethodManager.showSoftInput(editTexts[0], InputMethodManager.SHOW_FORCED);
-        }
-
     }
 
     //Used to get response broadcast from activity
@@ -280,7 +253,7 @@ public abstract class BaseEntryFragment extends Fragment {
         }
         public void block(ViewGroup parent){
             for(int i=0; i<parent.getChildCount(); i++){
-                if (parent.getChildAt(i) instanceof EditText || parent.getChildAt(i) instanceof Button) {
+                if (parent.getChildAt(i) instanceof TextField || parent.getChildAt(i) instanceof Button) {
                     if(parent.getChildAt(i).getVisibility() == View.VISIBLE && parent.getChildAt(i).isEnabled()){
                         parent.getChildAt(i).setEnabled(false);
                         blockedViews.add(parent.getChildAt(i));

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/EmptyFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/EmptyFragment.java
@@ -1,0 +1,58 @@
+package com.paxus.pay.poslinkui.demo.entry;
+
+import android.os.Bundle;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.paxus.pay.poslinkui.demo.R;
+import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
+
+public class EmptyFragment extends Fragment {
+
+    private String senderPackage;
+    private String action;
+
+    public EmptyFragment() {
+        // Required empty public constructor for newInstance
+    }
+
+    public static EmptyFragment newInstance(String senderPackage, String action) {
+        EmptyFragment emptyFragment = new EmptyFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString("senderPackage", senderPackage);
+        bundle.putString("action", action);
+        emptyFragment.setArguments(bundle);
+        return emptyFragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if(getArguments() != null) {
+            senderPackage = getArguments().getString("senderPackage");
+            action = getArguments().getString("action");
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_empty, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        getParentFragmentManager().setFragmentResultListener("keyCode", this, ((requestKey, result) -> {
+            if(result.getInt("keyCode") == KeyEvent.KEYCODE_BACK) {
+                EntryRequestUtils.sendAbort(requireContext(), senderPackage, action);
+            }
+        }));
+    }
+
+}

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/EntryActivity.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/EntryActivity.java
@@ -159,8 +159,10 @@ public class EntryActivity extends AppCompatActivity{
 
             if(!getSupportFragmentManager().isStateSaved()) {
                 getSupportFragmentManager().beginTransaction()
-                    .setCustomAnimations(R.anim.anim_enter_from_bottom, R.anim.anim_exit_to_bottom)
-                    .replace(R.id.status_container, statusFragment).commit();
+                        .setCustomAnimations(R.anim.anim_enter_from_right, R.anim.anim_exit_to_left, R.anim.anim_enter_from_right, R.anim.anim_exit_to_left)
+                        .replace(R.id.fragment_placeholder, EmptyFragment.newInstance(getIntent().getStringExtra(EntryExtraData.PARAM_PACKAGE), getIntent().getAction()))
+                        .setCustomAnimations(R.anim.anim_enter_from_bottom, R.anim.anim_exit_to_bottom)
+                        .replace(R.id.status_container, statusFragment).commit();
             }
         }
     }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/AConfirmationFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/AConfirmationFragment.java
@@ -14,6 +14,7 @@ import com.pax.us.pay.ui.constant.entry.EntryExtraData;
 import com.pax.us.pay.ui.constant.entry.EntryRequest;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Abstract class for all entry actions defined in {@link ConfirmationEntry} <br>
@@ -78,4 +79,8 @@ public abstract class AConfirmationFragment extends BaseEntryFragment {
         return (options != null && options.length>1) ? options[1] : null;
     }
 
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
+    }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/ConfirmReceiptViewFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/ConfirmReceiptViewFragment.java
@@ -24,6 +24,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.io.IOException;
 
@@ -115,5 +116,10 @@ public class ConfirmReceiptViewFragment extends BaseEntryFragment {
         Bundle bundle = new Bundle();
         bundle.putBoolean(EntryRequest.PARAM_CONFIRMED, true);
         sendNext(bundle);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/ConfirmSurchargeFeeFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/ConfirmSurchargeFeeFragment.java
@@ -13,6 +13,7 @@ import com.pax.us.pay.ui.constant.entry.EntryRequest;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement confirmation entry action {@value ConfirmationEntry#ACTION_CONFIRM_SURCHARGE_FEE}
@@ -86,5 +87,10 @@ public class ConfirmSurchargeFeeFragment extends BaseEntryFragment {
         Bundle bundle = new Bundle();
         bundle.putBoolean(EntryRequest.PARAM_CONFIRMED, confirm);
         sendNext(bundle);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/DisplayQRCodeReceiptFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/DisplayQRCodeReceiptFragment.java
@@ -20,6 +20,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.Hashtable;
 
@@ -109,5 +110,10 @@ public class DisplayQRCodeReceiptFragment extends BaseEntryFragment {
     @Override
     protected void executeBackPressEvent() {
         sendNext(null);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/StartUIFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/confirmation/StartUIFragment.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import com.pax.us.pay.ui.constant.entry.ConfirmationEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement confirmation entry action {@value ConfirmationEntry#ACTION_START_UI}
@@ -33,5 +34,10 @@ public class StartUIFragment extends BaseEntryFragment {
 
     @Override protected void executeBackPressEvent() {
         return;
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/information/DisplayTransInfoFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/information/DisplayTransInfoFragment.java
@@ -11,6 +11,7 @@ import com.pax.us.pay.ui.constant.entry.EntryExtraData;
 import com.pax.us.pay.ui.constant.entry.InformationEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement information entry action {@value InformationEntry#ACTION_DISPLAY_TRANS_INFORMATION}
@@ -55,5 +56,10 @@ public class DisplayTransInfoFragment extends BaseEntryFragment {
     @Override
     protected void onConfirmButtonClicked(){
         sendNext(null);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/option/AOptionEntryFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/option/AOptionEntryFragment.java
@@ -16,6 +16,7 @@ import com.pax.us.pay.ui.constant.entry.OptionEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.view.SelectOptionsView;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -84,4 +85,8 @@ public abstract class AOptionEntryFragment extends BaseEntryFragment {
 
     protected abstract String formatTitle();
 
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
+    }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/InputTextFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/InputTextFragment.java
@@ -9,7 +9,6 @@ import android.text.TextWatcher;
 import android.text.method.DigitsKeyListener;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -23,6 +22,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.lang.ref.WeakReference;
 
@@ -43,7 +43,7 @@ public class InputTextFragment extends BaseEntryFragment {
     private String inputType;
     private String defaultValue;
 
-    private EditText editText;
+    private TextField textField;
 
     @Override
     protected int getLayoutResourceId() {
@@ -72,88 +72,87 @@ public class InputTextFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(title);
 
-        editText = rootView.findViewById(R.id.edit_text);
-        focusableEditTexts = new EditText[]{editText};
+        textField = rootView.findViewById(R.id.edit_text);
 
         if ("1".equals(inputType)) {
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
             if(maxLength > 0 ) {
-                editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+                textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
             }
-            editText.setText(defaultValue);
+            textField.setText(defaultValue);
 
         } else if("2".equals(inputType)) {//Date
             minLength = 8;
             maxLength = 8;
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-            editText.setHint(FORMAT_DATE);
-            editText.setTextIsSelectable(false);
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(editText.getHint().length())});
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789/"));
-            editText.addTextChangedListener(new FormatTextWatcher(FORMAT_DATE));
-            editText.setText(defaultValue);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setHint(FORMAT_DATE);
+            textField.setTextIsSelectable(false);
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(textField.getHint().length())});
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789/"));
+            textField.addTextChangedListener(new FormatTextWatcher(FORMAT_DATE));
+            textField.setText(defaultValue);
 
         } else if("3".equals(inputType)) {//Time
             minLength = 6;
             maxLength = 6;
-            editText.setTextIsSelectable(false);
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-            editText.setHint(FORMAT_TIME);
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(editText.getHint().length())});
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789:"));
-            editText.addTextChangedListener(new FormatTextWatcher(FORMAT_TIME));
-            editText.setText(defaultValue);
+            textField.setTextIsSelectable(false);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setHint(FORMAT_TIME);
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(textField.getHint().length())});
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789:"));
+            textField.addTextChangedListener(new FormatTextWatcher(FORMAT_TIME));
+            textField.setText(defaultValue);
 
         } else if("4".equals(inputType)) {//Amount
-            editText.setTextIsSelectable(false);
-            editText.addTextChangedListener(new CurrencyTextWatcher(editText, CurrencyType.USD, maxLength));
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL | InputType.TYPE_NUMBER_FLAG_SIGNED);
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789,.$€£"));
-            editText.setHint(CurrencyUtils.CURRENCY_SYMBOL_MAP.get(CurrencyType.USD) + "0.00");
+            textField.setTextIsSelectable(false);
+            textField.addTextChangedListener(new CurrencyTextWatcher(textField, CurrencyType.USD, maxLength));
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL | InputType.TYPE_NUMBER_FLAG_SIGNED);
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789,.$€£"));
+            textField.setHint(CurrencyUtils.CURRENCY_SYMBOL_MAP.get(CurrencyType.USD) + "0.00");
 
             if(defaultValue != null) {
                 String def = defaultValue.replaceAll("[^0-9]","");
                 if(!TextUtils.isEmpty(def)) {
-                    editText.setText(CurrencyUtils.convert(Long.parseLong(def), CurrencyType.USD));
+                    textField.setText(CurrencyUtils.convert(Long.parseLong(def), CurrencyType.USD));
                 }
             }
 
         } else if("5".equals(inputType)) {//password
-            editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+            textField.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
             if(maxLength > 0 ) {
-                editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+                textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
             }
-            editText.setText(defaultValue);
+            textField.setText(defaultValue);
 
         } else if("6".equals(inputType)) {//Phone
             minLength = 10;
             maxLength = 10;
 
-            editText.setTextIsSelectable(false);
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-            editText.setHint(FORMAT_PHONE);
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(editText.getHint().length())});
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789-()"));
-            editText.addTextChangedListener(new FormatTextWatcher(FORMAT_PHONE));
-            editText.setText(defaultValue);
+            textField.setTextIsSelectable(false);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setHint(FORMAT_PHONE);
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(textField.getHint().length())});
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789-()"));
+            textField.addTextChangedListener(new FormatTextWatcher(FORMAT_PHONE));
+            textField.setText(defaultValue);
 
         } else if("7".equals(inputType)) {//SSN
             minLength = 9;
             maxLength = 9;
-            editText.setTextIsSelectable(false);
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-            editText.setHint(FORMAT_SSN);
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(editText.getHint().length())});
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789-"));
-            editText.addTextChangedListener(new FormatTextWatcher(FORMAT_SSN));
-            editText.setText(defaultValue);
+            textField.setTextIsSelectable(false);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setHint(FORMAT_SSN);
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(textField.getHint().length())});
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789-"));
+            textField.addTextChangedListener(new FormatTextWatcher(FORMAT_SSN));
+            textField.setText(defaultValue);
 
         } else {
-            editText.setInputType(InputType.TYPE_CLASS_TEXT);
+            textField.setInputType(InputType.TYPE_CLASS_TEXT);
             if(maxLength > 0 ) {
-                editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+                textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
             }
-            editText.setText(defaultValue);
+            textField.setText(defaultValue);
 
         }
 
@@ -163,6 +162,11 @@ public class InputTextFragment extends BaseEntryFragment {
         if(timeOut > 0 ) {
             getParentFragmentManager().setFragmentResult(TaskScheduler.SCHEDULE, TaskScheduler.generateTaskRequestBundle(TaskScheduler.TASK.TIMEOUT, timeOut));
         }
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
     }
 
     @Override
@@ -177,7 +181,7 @@ public class InputTextFragment extends BaseEntryFragment {
 
     @Override
     protected void onConfirmButtonClicked() {
-        String value = editText.getText().toString();
+        String value = textField.getText().toString();
         if (inputType.matches("[23467]")) {
             value = value.replaceAll("[^0-9]", "");
         }
@@ -262,13 +266,13 @@ public class InputTextFragment extends BaseEntryFragment {
     }
 
     private class CurrencyTextWatcher implements TextWatcher {
-        private final WeakReference<EditText> editTextWeakReference;
+        private final WeakReference<TextField> editTextWeakReference;
         private String currencyType;
         private int maxLength;
 
         private String valueBeforeTextChange;
-        public CurrencyTextWatcher(EditText editText, String currencyType, int maxLength) {
-            this.editTextWeakReference = new WeakReference<>(editText);
+        public CurrencyTextWatcher(TextField textField, String currencyType, int maxLength) {
+            this.editTextWeakReference = new WeakReference<>(textField);
             this.currencyType = currencyType;
             this.maxLength = maxLength;
         }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowDialogFormFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowDialogFormFragment.java
@@ -17,6 +17,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry actions:<br>
@@ -93,4 +94,8 @@ public class ShowDialogFormFragment extends BaseEntryFragment {
         sendNext(bundle);
     }
 
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
+    }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowDialogFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowDialogFragment.java
@@ -17,6 +17,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry actions:<br>
@@ -132,4 +133,8 @@ public class ShowDialogFragment extends BaseEntryFragment {
         sendNext(bundle);
     }
 
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
+    }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowInputTextBoxFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowInputTextBoxFragment.java
@@ -10,7 +10,6 @@ import android.text.TextWatcher;
 import android.text.method.DigitsKeyListener;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -29,6 +28,7 @@ import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
 import com.paxus.pay.poslinkui.demo.view.AmountTextWatcher;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry actions:<br>
@@ -50,7 +50,7 @@ public class ShowInputTextBoxFragment extends BaseEntryFragment {
     private String inputType;
     private String defaultValue;
 
-    private EditText editText;
+    private TextField textField;
     private LinearLayout textLayout;
 
     //Interfaces of POSLink Category may need to listen to POSLinkStatus Broadcasts
@@ -107,82 +107,82 @@ public class ShowInputTextBoxFragment extends BaseEntryFragment {
             textLayout.setVisibility(View.VISIBLE);
         }
 
-        editText = rootView.findViewById(R.id.edit_text);
-        focusableEditTexts = new EditText[]{editText};
+        textField = rootView.findViewById(R.id.edit_text);
+
         if ("1".equals(inputType)) {
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
             if(maxLength > 0 ) {
-                editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+                textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
             }
-            editText.setText(defaultValue);
+            textField.setText(defaultValue);
         }else if("2".equals(inputType)){//Date
             minLength = 8;
             maxLength = 8;
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-            editText.setHint(FORMAT_DATE);
-            editText.setTextIsSelectable(false);
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(editText.getHint().length())});
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789/"));
-            editText.addTextChangedListener(new ShowInputTextBoxFragment.FormatTextWatcher(FORMAT_DATE));
-            editText.setText(defaultValue);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setHint(FORMAT_DATE);
+            textField.setTextIsSelectable(false);
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(textField.getHint().length())});
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789/"));
+            textField.addTextChangedListener(new ShowInputTextBoxFragment.FormatTextWatcher(FORMAT_DATE));
+            textField.setText(defaultValue);
 
         }else if("3".equals(inputType)){//Time
             minLength = 6;
             maxLength = 6;
-            editText.setTextIsSelectable(false);
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-            editText.setHint(FORMAT_TIME);
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(editText.getHint().length())});
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789:"));
-            editText.addTextChangedListener(new ShowInputTextBoxFragment.FormatTextWatcher(FORMAT_TIME));
-            editText.setText(defaultValue);
+            textField.setTextIsSelectable(false);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setHint(FORMAT_TIME);
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(textField.getHint().length())});
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789:"));
+            textField.addTextChangedListener(new ShowInputTextBoxFragment.FormatTextWatcher(FORMAT_TIME));
+            textField.setText(defaultValue);
 
         }else if("4".equals(inputType)){//Amount
-            editText.setTextIsSelectable(false);
+            textField.setTextIsSelectable(false);
             if(defaultValue != null) {
                 String def = defaultValue.replaceAll("[^0-9]","");
                 if(!TextUtils.isEmpty(def)) {
-                    editText.setText(CurrencyUtils.convert(Long.parseLong(def), CurrencyType.USD));
+                    textField.setText(CurrencyUtils.convert(Long.parseLong(def), CurrencyType.USD));
                 }
 
             }
-            editText.addTextChangedListener(new AmountTextWatcher(maxLength, CurrencyType.USD));
+            textField.addTextChangedListener(new AmountTextWatcher(maxLength, CurrencyType.USD));
         }else if("5".equals(inputType)){//password
-            editText.setInputType(InputType.TYPE_TEXT_VARIATION_PASSWORD);
+            textField.setInputType(InputType.TYPE_TEXT_VARIATION_PASSWORD);
             if(maxLength > 0 ) {
-                editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+                textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
             }
-            editText.setText(defaultValue);
+            textField.setText(defaultValue);
 
         }else if("6".equals(inputType)){//Phone
             minLength = 10;
             maxLength = 10;
 
-            editText.setTextIsSelectable(false);
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-            editText.setHint(FORMAT_PHONE);
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(editText.getHint().length())});
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789-()"));
-            editText.addTextChangedListener(new ShowInputTextBoxFragment.FormatTextWatcher(FORMAT_PHONE));
-            editText.setText(defaultValue);
+            textField.setTextIsSelectable(false);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setHint(FORMAT_PHONE);
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(textField.getHint().length())});
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789-()"));
+            textField.addTextChangedListener(new ShowInputTextBoxFragment.FormatTextWatcher(FORMAT_PHONE));
+            textField.setText(defaultValue);
 
         }else if("7".equals(inputType)){//SSN
             minLength = 9;
             maxLength = 9;
-            editText.setTextIsSelectable(false);
-            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-            editText.setHint(FORMAT_SSN);
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(editText.getHint().length())});
-            editText.setKeyListener(DigitsKeyListener.getInstance("0123456789-"));
-            editText.addTextChangedListener(new ShowInputTextBoxFragment.FormatTextWatcher(FORMAT_SSN));
-            editText.setText(defaultValue);
+            textField.setTextIsSelectable(false);
+            textField.setInputType(InputType.TYPE_CLASS_NUMBER);
+            textField.setHint(FORMAT_SSN);
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(textField.getHint().length())});
+            textField.setKeyListener(DigitsKeyListener.getInstance("0123456789-"));
+            textField.addTextChangedListener(new ShowInputTextBoxFragment.FormatTextWatcher(FORMAT_SSN));
+            textField.setText(defaultValue);
 
         }else {
-            editText.setInputType(InputType.TYPE_CLASS_TEXT);
+            textField.setInputType(InputType.TYPE_CLASS_TEXT);
             if(maxLength > 0 ) {
-                editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+                textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
             }
-            editText.setText(defaultValue);
+            textField.setText(defaultValue);
 
         }
 
@@ -195,8 +195,13 @@ public class ShowInputTextBoxFragment extends BaseEntryFragment {
     }
 
     @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
+    }
+
+    @Override
     protected void onConfirmButtonClicked(){
-        String value = editText.getText().toString();
+        String value = textField.getText().toString();
         if(inputType.matches("[23467]")){
             value = value.replaceAll("[^0-9]","");
         }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowItemFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowItemFragment.java
@@ -20,6 +20,7 @@ import com.pax.us.pay.ui.constant.status.POSLinkStatus;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -171,4 +172,8 @@ public class ShowItemFragment extends BaseEntryFragment {
         return null;
     }
 
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
+    }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
@@ -17,6 +17,7 @@ import com.pax.us.pay.ui.constant.status.POSLinkStatus;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -188,5 +189,10 @@ public class ShowMessageFragment extends BaseEntryFragment {
             this.msg1 = msg1;
             this.msg2 = msg2;
         }
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowSignatureBoxFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowSignatureBoxFragment.java
@@ -22,6 +22,7 @@ import com.paxus.pay.poslinkui.demo.entry.signature.ElectronicSignatureView;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -188,5 +189,10 @@ public class ShowSignatureBoxFragment extends BaseEntryFragment {
         countdownFuture.cancel(true);
         countdownUpdateScheduler.shutdownNow();
         super.onDestroy();
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowTextBoxFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowTextBoxFragment.java
@@ -31,6 +31,7 @@ import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -279,5 +280,10 @@ public class ShowTextBoxFragment extends BaseEntryFragment {
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
         bitmap.setPixels(pixels, 0, width, 0, 0, width, height);
         return bitmap;
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowThankYouFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowThankYouFragment.java
@@ -15,6 +15,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry actions:<br>
@@ -79,4 +80,8 @@ public class ShowThankYouFragment extends BaseEntryFragment {
         textView.setText(msg);
     }
 
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
+    }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ASecurityFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ASecurityFragment.java
@@ -23,6 +23,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement security entry actions:<br>
@@ -39,7 +40,7 @@ import com.paxus.pay.poslinkui.demo.utils.Logger;
  */
 public abstract class ASecurityFragment extends BaseEntryFragment {
 
-    protected TextView editText;
+    protected TextView textField;
     protected Button confirmButton;
     protected int secureLength;
     protected BroadcastReceiver receiver;
@@ -57,20 +58,20 @@ public abstract class ASecurityFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(formatMessage());
 
-        editText = rootView.findViewById(R.id.edit_security);
-        ViewTreeObserver observer = editText.getViewTreeObserver();
+        textField = rootView.findViewById(R.id.edit_security);
+        ViewTreeObserver observer = textField.getViewTreeObserver();
         observer.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
-                editText.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                textField.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                 onInputBoxLayoutReady();
                 mContentView = requireActivity().getWindow().findViewById(Window.ID_ANDROID_CONTENT);
                 if ("Q10A".equals(Build.MODEL)) {
-                    editText.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+                    textField.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
                         @Override
                         public void onLayoutChange(View view, int left, int top, int right, int bottom,
                                                    int oldLeft, int oldTop, int oldRight, int oldBottom) {
-                            Logger.d("Security EditText onLayoutChange:" + left + "," + top + "," + right + "," + bottom + "," + oldLeft + "," + oldTop + "," + oldRight + "," + oldBottom);
+                            Logger.d("Security Widget onLayoutChange:" + left + "," + top + "," + right + "," + bottom + "," + oldLeft + "," + oldTop + "," + oldRight + "," + oldBottom);
                             if (right != oldRight) {
                                 onInputBoxLayoutReady();
                             }
@@ -100,10 +101,10 @@ public abstract class ASecurityFragment extends BaseEntryFragment {
     protected void onInputBoxLayoutReady() {
         if (Build.MODEL.equals("A35")) {
             new Handler().postDelayed(() -> {
-                sendSecurityArea(editText);
+                sendSecurityArea(textField);
             }, 100);
         } else {
-            sendSecurityArea(editText);
+            sendSecurityArea(textField);
         }
     }
 
@@ -175,6 +176,11 @@ public abstract class ASecurityFragment extends BaseEntryFragment {
             }
 
         }
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }
 

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/AdministratorPasswordFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/AdministratorPasswordFragment.java
@@ -19,6 +19,7 @@ import com.pax.us.pay.ui.constant.entry.enumeration.AdminPasswordType;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.Locale;
 
@@ -91,5 +92,10 @@ public class AdministratorPasswordFragment extends BaseEntryFragment {
         } else {
             sendSecurityArea(inputTextView);
         }
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/InputAccountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/InputAccountFragment.java
@@ -32,6 +32,7 @@ import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.utils.ValuePatternUtils;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement security entry actions {@link SecurityEntry#ACTION_INPUT_ACCOUNT}
@@ -91,6 +92,11 @@ public class InputAccountFragment extends BaseEntryFragment {
     @Override
     protected void onConfirmButtonClicked() {
         sendNext(null);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 
     @Override
@@ -162,7 +168,7 @@ public class InputAccountFragment extends BaseEntryFragment {
                     mContentView = requireActivity().getWindow().findViewById(Window.ID_ANDROID_CONTENT);
                     if ("Q10A".equals(Build.MODEL)) {
                         panInputBox.addOnLayoutChangeListener((view, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
-                            Logger.d("Security EditText onLayoutChange:" + left + "," + top + "," + right + "," + bottom + "," + oldLeft + "," + oldTop + "," + oldRight + "," + oldBottom);
+                            Logger.d("Security Widget onLayoutChange:" + left + "," + top + "," + right + "," + bottom + "," + oldLeft + "," + oldTop + "," + oldRight + "," + oldBottom);
                             if (right != oldRight) {
                                 onPanInputBoxLayoutReady(panInputBox);
                             }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ManageInputAccountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/ManageInputAccountFragment.java
@@ -27,6 +27,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.utils.ValuePatternUtils;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement security entry actions {@link SecurityEntry#ACTION_MANAGE_INPUT_ACCOUNT}
@@ -83,6 +84,11 @@ public class ManageInputAccountFragment extends BaseEntryFragment {
     @Override
     protected void onConfirmButtonClicked() {
         sendNext(null);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 
     private void onUpdateEntryMode(Intent intent) {
@@ -168,7 +174,7 @@ public class ManageInputAccountFragment extends BaseEntryFragment {
                                                        int oldTop,
                                                        int oldRight,
                                                        int oldBottom) {
-                                Logger.d("Security EditText onLayoutChange:" + left + "," + top + "," + right + "," + bottom + "," + oldLeft + "," + oldTop + "," + oldRight + "," + oldBottom);
+                                Logger.d("Security Widget onLayoutChange:" + left + "," + top + "," + right + "," + bottom + "," + oldLeft + "," + oldTop + "," + oldRight + "," + oldBottom);
                                 if (right != oldRight) {
                                     onPanInputBoxLayoutReady();
                                 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/PINFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/security/PINFragment.java
@@ -26,6 +26,7 @@ import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.utils.DeviceUtils;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -201,5 +202,8 @@ public class PINFragment extends BaseEntryFragment {
         }
     }
 
-
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
+    }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/signature/SignatureFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/signature/SignatureFragment.java
@@ -22,6 +22,7 @@ import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -196,5 +197,10 @@ public class SignatureFragment extends BaseEntryFragment {
         countdownFuture.cancel(true);
         countdownUpdateScheduler.shutdownNow();
         super.onDestroy();
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/AVSFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/AVSFragment.java
@@ -5,7 +5,6 @@ import android.text.InputFilter;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 
@@ -15,8 +14,8 @@ import com.pax.us.pay.ui.constant.entry.TextEntry;
 import com.pax.us.pay.ui.constant.entry.enumeration.InputType;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
-import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
 import com.paxus.pay.poslinkui.demo.utils.ValuePatternUtils;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry action {@value TextEntry#ACTION_ENTER_AVS_DATA}<br>
@@ -29,8 +28,8 @@ public class AVSFragment extends BaseEntryFragment {
     private int maxLengthZip;
     private boolean zipText;
 
-    private EditText editTextAddr;
-    private EditText editTextZip;
+    private TextField editTextAddr;
+    private TextField editTextZip;
 
     @Override
     protected int getLayoutResourceId() {
@@ -62,7 +61,6 @@ public class AVSFragment extends BaseEntryFragment {
     protected void loadView(View rootView) {
         editTextAddr = rootView.findViewById(R.id.edit_address);
         editTextZip = rootView.findViewById(R.id.edit_zip);
-        focusableEditTexts = new EditText[]{editTextAddr, editTextZip};
 
         if(maxLengthAddr > 0 ) editTextAddr.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLengthAddr)});
         if(maxLengthZip > 0 ) editTextZip.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLengthZip)});
@@ -87,5 +85,10 @@ public class AVSFragment extends BaseEntryFragment {
         bundle.putString(EntryRequest.PARAM_ADDRESS, addr);
         bundle.putString(EntryRequest.PARAM_ZIP_CODE, zip);
         sendNext(bundle);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{editTextZip, editTextAddr};
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/EnterOrigTransDateFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/EnterOrigTransDateFragment.java
@@ -5,7 +5,6 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -16,7 +15,7 @@ import com.pax.us.pay.ui.constant.entry.TextEntry;
 import com.pax.us.pay.ui.constant.entry.enumeration.DateFormat;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
-import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +28,7 @@ public class EnterOrigTransDateFragment extends BaseEntryFragment {
     private long timeOut;
     private String message = "";
     private String dateFormat;
-    private EditText editText;
+    private TextField textField;
 
     @Override
     protected int getLayoutResourceId() {
@@ -56,19 +55,23 @@ public class EnterOrigTransDateFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(message);
 
-        editText = rootView.findViewById(R.id.edit_expiry);
-        focusableEditTexts = new EditText[]{editText};
-        editText.setHint(hintMap.get(dateFormat));
-        editText.setSelection(editText.getEditableText().length());
-        editText.addTextChangedListener(new DateTextWatcher(dateFormat));
+        textField = rootView.findViewById(R.id.edit_expiry);
+        textField.setHint(hintMap.get(dateFormat));
+        textField.setSelection(textField.getEditableText().length());
+        textField.addTextChangedListener(new DateTextWatcher(dateFormat));
 
         Button confirmBtn = rootView.findViewById(R.id.confirm_button);
         confirmBtn.setOnClickListener(v -> onConfirmButtonClicked());
     }
 
     @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
+    }
+
+    @Override
     protected void onConfirmButtonClicked() {
-        String value = editText.getText().toString();
+        String value = textField.getText().toString();
         value = value.replaceAll("[^0-9]", "");
         submit(value);
     }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/ExpiryFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/ExpiryFragment.java
@@ -5,7 +5,6 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -16,6 +15,7 @@ import com.pax.us.pay.ui.constant.entry.TextEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.EntryRequestUtils;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry action {@value TextEntry#ACTION_ENTER_EXPIRY_DATE}<br>
@@ -24,7 +24,7 @@ public class ExpiryFragment extends BaseEntryFragment {
     private long timeOut;
     private String message = "";
 
-    private EditText editText;
+    private TextField textField;
 
     @Override
     protected int getLayoutResourceId() {
@@ -44,10 +44,10 @@ public class ExpiryFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(message);
 
-        editText = rootView.findViewById(R.id.edit_expiry);
+        textField = rootView.findViewById(R.id.edit_expiry);
 
-        editText.setSelection(editText.getEditableText().length());
-        editText.addTextChangedListener(new TextWatcher() {
+        textField.setSelection(textField.getEditableText().length());
+        textField.addTextChangedListener(new TextWatcher() {
             protected boolean mEditing;
             private String mPreStr;
 
@@ -87,17 +87,20 @@ public class ExpiryFragment extends BaseEntryFragment {
 
         Button confirmBtn = rootView.findViewById(R.id.confirm_button);
         confirmBtn.setOnClickListener(v -> onConfirmButtonClicked());
-
-        focusableEditTexts = new EditText[]{editText};
     }
 
     @Override
     protected void onConfirmButtonClicked() {
-        String value = editText.getText().toString();
+        String value = textField.getText().toString();
         value = value.replaceAll("[^0-9]", "");
         if (value.length() == 4) {
             submit(value);
         }
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
     }
 
     private void submit(String value) {
@@ -109,6 +112,6 @@ public class ExpiryFragment extends BaseEntryFragment {
     @Override
     public void onDestroy(){
         super.onDestroy();
-        editText.clearFocus();
+        textField.clearFocus();
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/AAmountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/AAmountFragment.java
@@ -3,7 +3,6 @@ package com.paxus.pay.poslinkui.demo.entry.text.amount;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.LayoutRes;
@@ -13,6 +12,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.view.AmountTextWatcher;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry actions:<br>
@@ -23,7 +23,7 @@ import com.paxus.pay.poslinkui.demo.view.AmountTextWatcher;
 
 public abstract class AAmountFragment extends BaseEntryFragment {
 
-    private EditText editText;
+    private TextField textField;
 
     @Override
     protected @LayoutRes
@@ -36,12 +36,11 @@ public abstract class AAmountFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(formatMessage());
 
-        editText = rootView.findViewById(R.id.edit_amount);
-        focusableEditTexts = new EditText[]{editText};
-        editText.setSelected(true);
-        editText.setText(CurrencyUtils.convert(0, getCurrency()));
-        editText.setSelection(editText.getEditableText().length());
-        editText.addTextChangedListener(new AmountTextWatcher(getMaxLength(), getCurrency()));
+        textField = rootView.findViewById(R.id.edit_amount);
+        textField.setSelected(true);
+        textField.setText(CurrencyUtils.convert(0, getCurrency()));
+        textField.setSelection(textField.getEditableText().length());
+        textField.addTextChangedListener(new AmountTextWatcher(getMaxLength(), getCurrency()));
 
         Button confirmBtn = rootView.findViewById(R.id.confirm_button);
         confirmBtn.setOnClickListener(v -> onConfirmButtonClicked());
@@ -49,13 +48,18 @@ public abstract class AAmountFragment extends BaseEntryFragment {
 
     @Override
     protected void onConfirmButtonClicked() {
-        submit(CurrencyUtils.parse(editText.getText().toString()));
+        submit(CurrencyUtils.parse(textField.getText().toString()));
     }
 
     protected void submit(long value) {
         Bundle bundle = new Bundle();
         bundle.putLong(getRequestedParamName(), value);
         sendNext(bundle);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
     }
 
     protected abstract String getRequestedParamName();

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/CashbackFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/CashbackFragment.java
@@ -6,11 +6,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.Editable;
 import android.text.TextUtils;
-import android.text.TextWatcher;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
-import android.widget.CheckedTextView;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -22,10 +19,10 @@ import com.pax.us.pay.ui.constant.entry.enumeration.CurrencyType;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
-import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.utils.ValuePatternUtils;
 import com.paxus.pay.poslinkui.demo.view.AmountTextWatcher;
 import com.paxus.pay.poslinkui.demo.view.SelectOptionsView;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,6 +41,8 @@ public class CashbackFragment extends BaseEntryFragment {
     private List<SelectOptionsView.Option> optionList = new ArrayList<>();
 
     private long cashback = 0;
+
+    TextField editCashback;
 
     @Override
     protected int getLayoutResourceId() {
@@ -82,7 +81,7 @@ public class CashbackFragment extends BaseEntryFragment {
         boolean isSelectCashbackEnabled = !optionList.isEmpty();
 
         SelectOptionsView cashbackOptionsView = rootView.findViewById(R.id.options_layout);
-        EditText editCashback = rootView.findViewById(R.id.edit_cashback);
+        editCashback = rootView.findViewById(R.id.edit_cashback);
 
         if(isSelectCashbackEnabled) {
             ((TextView)rootView.findViewById(R.id.message)).setText(getString(R.string.select_cashback_amount));
@@ -100,7 +99,6 @@ public class CashbackFragment extends BaseEntryFragment {
             }
         } else {
             editCashback.setVisibility(View.VISIBLE);
-            focusableEditTexts = new EditText[]{editCashback};
         }
         if(editCashback.getVisibility() == View.VISIBLE){
             editCashback.addTextChangedListener(new CashbackEditTextWatcher(maxLength,currency, value -> this.cashback = value));
@@ -145,5 +143,10 @@ public class CashbackFragment extends BaseEntryFragment {
         Bundle bundle = new Bundle();
         bundle.putLong(EntryRequest.PARAM_CASHBACK_AMOUNT, value);
         sendNext(bundle);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return optionList.isEmpty() ? new TextField[]{editCashback} : null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
@@ -9,10 +9,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
-import android.widget.CheckedTextView;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -31,6 +28,7 @@ import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.utils.ValuePatternUtils;
 import com.paxus.pay.poslinkui.demo.view.AmountTextWatcher;
 import com.paxus.pay.poslinkui.demo.view.SelectOptionsView;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,6 +50,8 @@ public class TipFragment extends BaseEntryFragment {
 
     private List<SelectOptionsView.Option> tipOptionList = new ArrayList<>();
     private List<TipInfo> tipInfoList = new ArrayList<>();
+
+    private TextField tipInputEditText;
 
     long tip = 0;
 
@@ -131,7 +131,7 @@ public class TipFragment extends BaseEntryFragment {
 
         //Select and Enter Tip
         SelectOptionsView tipOptionsView = rootView.findViewById(R.id.select_view_tip_options);
-        EditText tipInputEditText = rootView.findViewById(R.id.edit_text_tip_entry);
+        tipInputEditText = rootView.findViewById(R.id.edit_text_tip_entry);
         if(isSelectTipEnabled){
             tipOptionsView.setVisibility(View.VISIBLE);
             tipOptionsView.initialize(getActivity(), tipOptionList.size(), tipOptionList, option -> {
@@ -147,8 +147,6 @@ public class TipFragment extends BaseEntryFragment {
                 if (actionId == EditorInfo.IME_ACTION_DONE) onConfirmButtonClicked();
                 return true;
             });
-        } else {
-            focusableEditTexts = new EditText[]{tipInputEditText};
         }
 
         //No Tip Option
@@ -171,6 +169,7 @@ public class TipFragment extends BaseEntryFragment {
             }
         });
         tipInputEditText.setText(String.valueOf(tip)); //Initialize TextWatcher with Default Tip Value
+        tipInputEditText.setSelection(tipInputEditText.getEditableText().length());
 
         //Confirm
         Button confirmButton = rootView.findViewById(R.id.button_confirm);
@@ -236,5 +235,10 @@ public class TipFragment extends BaseEntryFragment {
         }
 
         sendNext(bundle);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return isSelectTipEnabled ? null : new TextField[]{tipInputEditText};
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TotalAmountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TotalAmountFragment.java
@@ -4,7 +4,6 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -18,6 +17,7 @@ import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.utils.ValuePatternUtils;
 import com.paxus.pay.poslinkui.demo.view.AmountTextWatcher;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry action {@value TextEntry#ACTION_ENTER_TOTAL_AMOUNT}<br>
@@ -39,7 +39,7 @@ public class TotalAmountFragment extends BaseEntryFragment {
     private boolean noTipEnabled;
     private String tipName;
 
-    private EditText editText;
+    private TextField textField;
 
     @Override
     protected int getLayoutResourceId() {
@@ -70,12 +70,11 @@ public class TotalAmountFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(message);
 
-        editText = rootView.findViewById(R.id.edit_amount);
-        focusableEditTexts = new EditText[]{editText};
-        editText.setSelected(false);
-        editText.setText(CurrencyUtils.convert(0,currency));
-        editText.setSelection(editText.getEditableText().length());
-        editText.addTextChangedListener(new AmountTextWatcher(maxLength, currency));
+        textField = rootView.findViewById(R.id.edit_amount);
+        textField.setSelected(false);
+        textField.setText(CurrencyUtils.convert(0,currency));
+        textField.setSelection(textField.getEditableText().length());
+        textField.addTextChangedListener(new AmountTextWatcher(maxLength, currency));
 
         Button confirmBtn = rootView.findViewById(R.id.confirm_button);
         confirmBtn.setOnClickListener(v -> onConfirmButtonClicked());
@@ -110,7 +109,12 @@ public class TotalAmountFragment extends BaseEntryFragment {
 
     @Override
     protected void onConfirmButtonClicked(){
-        long value = CurrencyUtils.parse(editText.getText().toString());
+        long value = CurrencyUtils.parse(textField.getText().toString());
         submit(value);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fleet/EnterFleetDataFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fleet/EnterFleetDataFragment.java
@@ -5,8 +5,6 @@ import android.text.InputFilter;
 import android.text.InputType;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -18,6 +16,7 @@ import com.pax.us.pay.ui.constant.entry.TextEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.ValuePatternUtils;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +33,7 @@ public class EnterFleetDataFragment extends BaseEntryFragment {
     private Bundle output;
 
     private TextView title;
-    private EditText editText;
+    private TextField textField;
     private Button confirm;
 
     @Override
@@ -135,7 +134,7 @@ public class EnterFleetDataFragment extends BaseEntryFragment {
     protected void loadView(View rootView) {
         title = rootView.findViewById(R.id.message);
 
-        editText = rootView.findViewById(R.id.edit_number_text);
+        textField = rootView.findViewById(R.id.edit_number_text);
 
         confirm = rootView.findViewById(R.id.confirm_button);
         confirm.setOnClickListener(v -> onConfirmButtonClicked());
@@ -146,10 +145,14 @@ public class EnterFleetDataFragment extends BaseEntryFragment {
 
     private void setCurrentFleetData() {
         title.setText(currentFleetData.title);
-        editText.setInputType(currentFleetData.inputType);
-        editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(ValuePatternUtils.getMaxLength(currentFleetData.valuePattern))});
-        editText.setText("");
-        focusableEditTexts = new EditText[]{editText};
+        textField.setInputType(currentFleetData.inputType);
+        textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(ValuePatternUtils.getMaxLength(currentFleetData.valuePattern))});
+        textField.setText("");
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
     }
 
     private void resetFleetData() {
@@ -161,14 +164,13 @@ public class EnterFleetDataFragment extends BaseEntryFragment {
 
     @Override
     protected void onConfirmButtonClicked() {
-        if(editText.getText().toString().length() < ValuePatternUtils.getMinLength(currentFleetData.valuePattern)){
+        if(textField.getText().toString().length() < ValuePatternUtils.getMinLength(currentFleetData.valuePattern)){
             Toast.makeText(requireContext(), getString(R.string.min_length_verification, ValuePatternUtils.getMinLength(currentFleetData.valuePattern)), Toast.LENGTH_SHORT).show();
             return;
         }
 
-        currentFleetData.outputValue = editText.getText().toString();
+        currentFleetData.outputValue = textField.getText().toString();
         output.putString(currentFleetData.outputKey, currentFleetData.outputValue);
-        focusableEditTexts = null;
 
         boolean completed = true;
         for(IndividualFleetData fleetData: fleetDataList){

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fsa/FSAAmountFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fsa/FSAAmountFragment.java
@@ -5,7 +5,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -17,6 +16,7 @@ import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.utils.CurrencyUtils;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
 import com.paxus.pay.poslinkui.demo.view.AmountTextWatcher;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Fragment which used to input fsa amount
@@ -38,7 +38,7 @@ public class FSAAmountFragment extends Fragment {
     private String currency = "";
     private long totalAmount = 0;
 
-    private EditText editText;
+    private TextField textField;
 
 
 
@@ -90,14 +90,14 @@ public class FSAAmountFragment extends Fragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(message);
 
-        editText = rootView.findViewById(R.id.edit_amount);
-        editText.setSelected(false);
-        editText.setText(CurrencyUtils.convert(0,currency));
-        editText.setSelection(editText.getEditableText().length());
+        textField = rootView.findViewById(R.id.edit_amount);
+        textField.setSelected(false);
+        textField.setText(CurrencyUtils.convert(0,currency));
+        textField.setSelection(textField.getEditableText().length());
 
-        editText.addTextChangedListener(new AmountTextWatcher(maxLength, currency));
-        editText.requestFocus();
-        editText.requestFocusFromTouch();
+        textField.addTextChangedListener(new AmountTextWatcher(maxLength, currency));
+        textField.requestFocus();
+        textField.requestFocusFromTouch();
 
         Button confirmBtn = rootView.findViewById(R.id.confirm_button);
         confirmBtn.setOnClickListener(v -> onConfirmButtonClicked());
@@ -106,7 +106,7 @@ public class FSAAmountFragment extends Fragment {
     }
 
     private void onConfirmButtonClicked() {
-        long value = CurrencyUtils.parse(editText.getText().toString());
+        long value = CurrencyUtils.parse(textField.getText().toString());
         Bundle bundle = new Bundle();
         bundle.putLong(VALUE, value);
         getParentFragmentManager().setFragmentResult(RESULT, bundle);

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fsa/FSAFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/fsa/FSAFragment.java
@@ -15,6 +15,7 @@ import com.pax.us.pay.ui.constant.entry.enumeration.FSAType;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.Logger;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 import java.util.Arrays;
 import java.util.List;
@@ -268,5 +269,10 @@ public class FSAFragment extends BaseEntryFragment {
     @Override
     protected void onConfirmButtonClicked() {
         getChildFragmentManager().setFragmentResult(REQUEST_KEY_CONFIRM, new Bundle());
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/number/ANumFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/number/ANumFragment.java
@@ -4,12 +4,12 @@ import android.os.Bundle;
 import android.text.InputFilter;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import com.pax.us.pay.ui.constant.entry.TextEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry actions:<br>
@@ -25,7 +25,7 @@ import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
  */
 public abstract class ANumFragment extends BaseEntryFragment {
 
-    protected EditText editText;
+    protected TextField textField;
 
     @Override
     protected int getLayoutResourceId() {
@@ -38,11 +38,10 @@ public abstract class ANumFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(message);
 
-        editText = rootView.findViewById(R.id.edit_number);
-        focusableEditTexts = new EditText[]{editText};
+        textField = rootView.findViewById(R.id.edit_number);
         int maxLength = getMaxLength();
         if (maxLength > 0) {
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
         }
 
         Button confirmBtn = rootView.findViewById(R.id.confirm_button);
@@ -55,7 +54,7 @@ public abstract class ANumFragment extends BaseEntryFragment {
 
     @Override
     protected void onConfirmButtonClicked() {
-        String value = editText.getText().toString();
+        String value = textField.getText().toString();
         submit(value);
     }
 
@@ -63,6 +62,11 @@ public abstract class ANumFragment extends BaseEntryFragment {
         Bundle bundle = new Bundle();
         bundle.putString(getRequestedParamName(), value);
         sendNext(bundle);
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
     }
 
     protected abstract String getRequestedParamName();

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/numbertext/ANumTextFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/numbertext/ANumTextFragment.java
@@ -4,12 +4,12 @@ import android.os.Bundle;
 import android.text.InputFilter;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import com.pax.us.pay.ui.constant.entry.TextEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry actions:<br>
@@ -23,7 +23,7 @@ import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
  */
 public abstract class ANumTextFragment extends BaseEntryFragment {
 
-    protected EditText editText;
+    protected TextField textField;
 
     @Override
     protected int getLayoutResourceId() {
@@ -37,16 +37,15 @@ public abstract class ANumTextFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(message);
 
-        editText = rootView.findViewById(R.id.edit_number_text);
-        focusableEditTexts = new EditText[]{editText};
+        textField = rootView.findViewById(R.id.edit_number_text);
         int maxLength = getMaxLength();
         if (maxLength > 0) {
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
         }
         if (allowText()) {
-            editText.setInputType(android.text.InputType.TYPE_CLASS_TEXT);
+            textField.setInputType(android.text.InputType.TYPE_CLASS_TEXT);
         } else {
-            editText.setInputType(android.text.InputType.TYPE_CLASS_NUMBER);
+            textField.setInputType(android.text.InputType.TYPE_CLASS_NUMBER);
         }
         Button confirmBtn = rootView.findViewById(R.id.confirm_button);
         confirmBtn.setOnClickListener(v -> onConfirmButtonClicked());
@@ -55,7 +54,7 @@ public abstract class ANumTextFragment extends BaseEntryFragment {
 
     @Override
     protected void onConfirmButtonClicked() {
-        String value = editText.getText().toString();
+        String value = textField.getText().toString();
         submit(value);
     }
 
@@ -66,6 +65,11 @@ public abstract class ANumTextFragment extends BaseEntryFragment {
     protected abstract String formatMessage();
 
     protected abstract String getRequestedParamName();
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
+    }
 
     protected void submit(String value) {
         Bundle bundle = new Bundle();

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/text/ATextFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/text/ATextFragment.java
@@ -4,12 +4,12 @@ import android.os.Bundle;
 import android.text.InputFilter;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import com.pax.us.pay.ui.constant.entry.TextEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement text entry actions:<br>
@@ -22,7 +22,7 @@ import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
  */
 public abstract class ATextFragment extends BaseEntryFragment {
 
-    protected EditText editText;
+    protected TextField textField;
 
     @Override
     protected int getLayoutResourceId() {
@@ -34,15 +34,14 @@ public abstract class ATextFragment extends BaseEntryFragment {
         TextView textView = rootView.findViewById(R.id.message);
         textView.setText(formatMessage());
 
-        editText = rootView.findViewById(R.id.edit_text);
+        textField = rootView.findViewById(R.id.edit_text);
         int maxLength = getMaxLength();
         if (maxLength > 0) {
-            editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
+            textField.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
         }
 
         Button confirmBtn = rootView.findViewById(R.id.confirm_button);
         confirmBtn.setOnClickListener(v -> onConfirmButtonClicked());
-        focusableEditTexts = new EditText[]{editText};
     }
 
     protected abstract int getMaxLength();
@@ -51,7 +50,7 @@ public abstract class ATextFragment extends BaseEntryFragment {
 
     @Override
     protected void onConfirmButtonClicked() {
-        String value = editText.getText().toString();
+        String value = textField.getText().toString();
         submit(value);
     }
 
@@ -62,4 +61,9 @@ public abstract class ATextFragment extends BaseEntryFragment {
     }
 
     protected abstract String getRequestedParamName();
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return new TextField[]{textField};
+    }
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/status/StatusFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/status/StatusFragment.java
@@ -6,8 +6,6 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
@@ -50,10 +48,6 @@ public class StatusFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_status, container, false);
-
-        getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
-        InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-        inputMethodManager.hideSoftInputFromWindow(getActivity().getWindow().getDecorView().getWindowToken(), InputMethodManager.HIDE_IMPLICIT_ONLY);
 
         TextView titleTextView = view.findViewById(R.id.status_title);
         titleTextView.setText(message);

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/utils/Toast.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/utils/Toast.java
@@ -36,7 +36,7 @@ public class Toast {
         //add toast fragment
         activity.getSupportFragmentManager().executePendingTransactions();
         activity.getSupportFragmentManager().beginTransaction()
-                .setCustomAnimations(R.anim.anim_enter_from_right, R.anim.anim_exit_to_left)
+                .setCustomAnimations(R.anim.anim_enter_from_right, android.R.anim.fade_out)
                 .replace(R.id.toast_container, toastFragment).commit();
 
         //remove toast fragment after defined duration

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/view/SelectOptionsView.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/view/SelectOptionsView.java
@@ -199,7 +199,7 @@ public class SelectOptionsView extends RecyclerView {
             public void bindListener(final Option option, final OptionSelectListener listener) {
                 itemView.setOnClickListener(view -> {
                     InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-                    inputMethodManager.hideSoftInputFromWindow(context.getWindow().getDecorView().getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+//                    inputMethodManager.hideSoftInputFromWindow(context.getWindow().getDecorView().getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
                     listener.onSelect(option);
                     clear();
                     ((CheckedTextView) text).setChecked(true);

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/view/TextField.kt
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/view/TextField.kt
@@ -1,0 +1,173 @@
+package com.paxus.pay.poslinkui.demo.view
+
+import android.content.Context
+import android.graphics.Rect
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.ResultReceiver
+import android.text.InputType
+import android.util.AttributeSet
+import android.view.ViewTreeObserver
+import android.view.inputmethod.InputConnection
+import android.view.inputmethod.InputMethodManager
+import androidx.appcompat.widget.AppCompatEditText
+import androidx.core.content.res.ResourcesCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.paxus.pay.poslinkui.demo.R
+import com.paxus.pay.poslinkui.demo.utils.DeviceUtils
+import com.paxus.pay.poslinkui.demo.utils.Logger
+
+/**
+ * Created by Dhrubo Paul
+ */
+
+class TextField : AppCompatEditText {
+
+    private var keyboardOpened : Boolean = false
+    private var pressedIntentionally : Boolean = false
+
+    constructor(context: Context) : this(context, null)
+    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+        init()
+    }
+
+    private fun init() {
+        //Clickability
+        isFocusable = true
+        isFocusableInTouchMode = true
+        isClickable = true
+
+        //Accessibility
+        hint = ""
+        contentDescription = ""
+
+        //Input Method
+        showSoftInputOnFocus = true
+
+        //Styling
+        isCursorVisible = true
+        background = ResourcesCompat.getDrawable(resources, R.drawable.rounded_corner_on_background, null)
+        setTextColor(ResourcesCompat.getColor(resources, R.color.pastel_text_color_on_light, null))
+        setHintTextColor(ResourcesCompat.getColor(resources, R.color.pastel_text_color_on_light, null))
+        imeOptions = android.view.inputmethod.EditorInfo.IME_FLAG_NO_EXTRACT_UI
+        gravity = android.view.Gravity.CENTER
+        minHeight = resources.getDimensionPixelSize(R.dimen.button_height)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        imm().hideSoftInputFromWindow(windowToken, 0)
+        viewTreeObserver.removeOnGlobalLayoutListener(globalLayoutListener)
+    }
+
+    override fun performClick(): Boolean {
+        pressedIntentionally = true
+        if(hasFocus() && softKeyboardNeeded() && !keyboardOpened) {
+            ensureSoftKeyboardWhenReady()
+        }
+        return super.performClick()
+    }
+
+
+
+    override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+        super.onFocusChanged(focused, direction, previouslyFocusedRect)
+        if(focused) {
+            if(softKeyboardNeeded()) showSoftKeyboard() else hideSoftKeyboard()
+        } else {
+            hideSoftKeyboard()
+        }
+    }
+
+    private fun imm(): InputMethodManager {
+        return context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    }
+
+    private fun softKeyboardNeeded(): Boolean {
+        return if(DeviceUtils.hasPhysicalKeyboard() && !requiresAlphanumericKeyboard(inputType)) pressedIntentionally else true
+    }
+
+    private fun requiresAlphanumericKeyboard(inputType: Int): Boolean {
+        return when (inputType and InputType.TYPE_MASK_CLASS) {
+            InputType.TYPE_CLASS_TEXT -> true
+            InputType.TYPE_CLASS_NUMBER -> false
+            InputType.TYPE_CLASS_PHONE -> false
+            InputType.TYPE_CLASS_DATETIME -> false
+            else -> true
+        }
+    }
+
+    private val immResultReceiver = object : ResultReceiver(Handler(Looper.getMainLooper())) {
+        override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
+            super.onReceiveResult(resultCode, resultData)
+
+            keyboardOpened = resultCode == InputMethodManager.RESULT_SHOWN || resultCode == InputMethodManager.RESULT_UNCHANGED_SHOWN
+
+            val resultDescription = when (resultCode) {
+                InputMethodManager.RESULT_UNCHANGED_SHOWN -> "IMM: Soft keyboard already shown and unchanged"
+                InputMethodManager.RESULT_UNCHANGED_HIDDEN -> "IMM: Soft keyboard already hidden and unchanged"
+                InputMethodManager.RESULT_SHOWN -> "IMM: Soft keyboard shown successfully"
+                InputMethodManager.RESULT_HIDDEN -> "IMM: Soft keyboard hidden successfully"
+                else -> "IMM: Unknown result code ($resultCode)"
+            }
+            Logger.i("Keyboard Opened: $keyboardOpened")
+        }
+    }
+
+    fun attachToLifecycle(lifecycle: Lifecycle) {
+        val lifecycleObserver = object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                when (event) {
+                    Lifecycle.Event.ON_RESUME -> {
+                        if(softKeyboardNeeded()) Handler(Looper.getMainLooper()).post({ requestFocus() })
+                    }
+                    Lifecycle.Event.ON_PAUSE -> {
+                        hideSoftKeyboard()
+                    }
+                    Lifecycle.Event.ON_DESTROY -> {
+                        lifecycle.removeObserver(this) // Remove the observer explicitly
+                    }
+                    else -> {
+                    }
+                }
+            }
+        }
+        lifecycle.addObserver(lifecycleObserver)
+    }
+
+    private val globalLayoutListener: ViewTreeObserver.OnGlobalLayoutListener = object : ViewTreeObserver.OnGlobalLayoutListener {
+        override fun onGlobalLayout() {
+            showSoftKeyboard()
+            if (keyboardOpened) viewTreeObserver.removeOnGlobalLayoutListener(this)
+        }
+    }
+
+    private fun ensureSoftKeyboardWhenReady() {
+        if(keyboardOpened) return
+        if(isLaidOut) showSoftKeyboard()
+        while (!isAttachedToWindow){}
+        viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
+    }
+
+    private fun showSoftKeyboard() {
+        if(!softKeyboardNeeded() || keyboardOpened) return
+
+        (hasFocus() && imm().isActive(this) && isAttachedToWindow).let {
+            Handler(Looper.getMainLooper()).postDelayed({
+                imm().showSoftInput(this, InputMethodManager.SHOW_IMPLICIT, immResultReceiver)
+                requestLayout()
+            }, 200)
+        }
+
+    }
+
+    private fun hideSoftKeyboard() {
+        Handler(Looper.getMainLooper()).post({
+            imm().hideSoftInputFromWindow(windowToken, InputMethodManager.HIDE_IMPLICIT_ONLY, immResultReceiver)
+        })
+    }
+}

--- a/app/src/main/res/layout/fragment_amount.xml
+++ b/app/src/main/res/layout/fragment_amount.xml
@@ -9,7 +9,7 @@
         android:id="@+id/message"
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_amount"

--- a/app/src/main/res/layout/fragment_avs.xml
+++ b/app/src/main/res/layout/fragment_avs.xml
@@ -11,7 +11,7 @@
         android:textSize="@dimen/text_size_title"
         android:text="@string/pls_input_address"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_address"
@@ -23,7 +23,7 @@
         android:text="@string/pls_input_zip_code"
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_zip"

--- a/app/src/main/res/layout/fragment_base_num.xml
+++ b/app/src/main/res/layout/fragment_base_num.xml
@@ -9,7 +9,7 @@
         android:id="@+id/message"
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_number"

--- a/app/src/main/res/layout/fragment_base_num_text.xml
+++ b/app/src/main/res/layout/fragment_base_num_text.xml
@@ -3,16 +3,19 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
+
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/message"
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/edit_number_text" />
+        android:layout_height="@dimen/button_height"
+        android:id="@+id/edit_number_text"/>
+
     <Button
         android:layout_width="match_parent"
         android:layout_height="@dimen/button_height"

--- a/app/src/main/res/layout/fragment_base_text.xml
+++ b/app/src/main/res/layout/fragment_base_text.xml
@@ -9,7 +9,7 @@
         android:id="@+id/message"
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_text"

--- a/app/src/main/res/layout/fragment_cashback.xml
+++ b/app/src/main/res/layout/fragment_cashback.xml
@@ -48,7 +48,7 @@
         app:layout_constraintBottom_toTopOf="@id/edit_cashback"
         />
 
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:id="@+id/edit_cashback"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_empty.xml
+++ b/app/src/main/res/layout/fragment_empty.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/pastel_background">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_expiry.xml
+++ b/app/src/main/res/layout/fragment_expiry.xml
@@ -9,7 +9,7 @@
         android:id="@+id/message"
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_expiry"

--- a/app/src/main/res/layout/fragment_fleet.xml
+++ b/app/src/main/res/layout/fragment_fleet.xml
@@ -9,9 +9,10 @@
         android:id="@+id/message"
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/button_height"
         android:id="@+id/edit_number_text"
         />
     <Button

--- a/app/src/main/res/layout/fragment_fsa_amount.xml
+++ b/app/src/main/res/layout/fragment_fsa_amount.xml
@@ -27,7 +27,7 @@
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"
         />
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_amount"

--- a/app/src/main/res/layout/fragment_input_text.xml
+++ b/app/src/main/res/layout/fragment_input_text.xml
@@ -10,7 +10,7 @@
         android:id="@+id/message"
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_text"

--- a/app/src/main/res/layout/fragment_input_text_box.xml
+++ b/app/src/main/res/layout/fragment_input_text_box.xml
@@ -15,7 +15,7 @@
         android:id="@+id/text_view"
         android:layout_marginTop="8dp"
         android:orientation="horizontal"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_text"

--- a/app/src/main/res/layout/fragment_orig_trans_date.xml
+++ b/app/src/main/res/layout/fragment_orig_trans_date.xml
@@ -11,7 +11,7 @@
         android:textSize="@dimen/text_size_title"
         android:layout_marginVertical="@dimen/space_between_textview"/>
 
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:id="@+id/edit_expiry"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_tip.xml
+++ b/app/src/main/res/layout/fragment_tip.xml
@@ -74,7 +74,7 @@
         app:layout_constraintBottom_toTopOf="@id/edit_text_tip_entry"
         />
 
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:id="@+id/edit_text_tip_entry"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_total_amount.xml
+++ b/app/src/main/res/layout/fragment_total_amount.xml
@@ -25,7 +25,7 @@
         android:id="@+id/message"
         android:textSize="@dimen/text_size_title"
         />
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/edit_amount"

--- a/app/src/main/res/layout/item_cashback_option.xml
+++ b/app/src/main/res/layout/item_cashback_option.xml
@@ -9,7 +9,7 @@
         android:id="@+id/option_item"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
-    <EditText
+    <com.paxus.pay.poslinkui.demo.view.TextField
         android:id="@+id/edit_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ task clean(type: Delete) {
 buildscript {
     ext {
         agp_version = '7.4.0'
+        kotlin_version = '1.9.22'
     }
     repositories {
         google()
@@ -21,6 +22,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$agp_version"
         classpath "com.alibaba:arouter-register:1.0.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-313
https://pax-us.atlassian.net/browse/POSUI-315
https://pax-us.atlassian.net/browse/POSUI-317

### Related Pull Requests  

### How do you fix?  


### Test Evidence
**POSUI-313 without keypad (A77)**

https://github.com/user-attachments/assets/fa78608d-f532-4b05-92ae-4b3bde9d1c86


**POSUI-313 with keypad (Aries8)**

https://github.com/user-attachments/assets/78598051-47cc-478d-b154-69f218d96f72

**POSUI-315 without keypad (A77)**

https://github.com/user-attachments/assets/bf292fa8-6fd7-454d-aa41-4b48c76b62ff

**POSUI-315 with keypad (Aries8)**

https://github.com/user-attachments/assets/a205d6db-4928-4433-8467-bc83f7f9a9b1

**POSUI-317 without keypad (A77)**

https://github.com/user-attachments/assets/6e824124-faed-4acf-adb1-fd8737e14199

**POSUI-317 with keypad (Aries8)**

https://github.com/user-attachments/assets/23b91c06-b756-4fec-a5be-87309ce9b8ec