### PR TITLE
[BPOSANDJAX-1246][POSLink UI] "Abort" message does not prompt when canceling EDC transaction

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/status/TransCompletedStatusFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/status/TransCompletedStatusFragment.java
@@ -15,8 +15,6 @@ import com.paxus.pay.poslinkui.demo.utils.TaskScheduler;
 public class TransCompletedStatusFragment extends StatusFragment {
     private long code, delay;
 
-    private static final long TRANS_RESULT_CODE_FOR_INSTANT_TERMINATION = -3;
-
     public TransCompletedStatusFragment(Intent intent, Context context) {
         super(intent, context);
         this.code = getArguments().getLong(StatusData.PARAM_CODE);
@@ -36,6 +34,7 @@ public class TransCompletedStatusFragment extends StatusFragment {
 
     @Override
     public boolean isImmediateTerminationNeeded() {
-        return this.message == null || this.message.isEmpty() || this.code == TRANS_RESULT_CODE_FOR_INSTANT_TERMINATION;
+        // [BPOSANDJAX-1246]  regardless of whether the POSLink UI is installed BroadPOS must display the prompt “ABORTED” when a transaction is canceled.
+        return this.message == null || this.message.isEmpty();
     }
 }


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/BPOSANDJAX-1246


### Related Pull Requests  
* https://github.com/PAXTechnologyInc/BroadPOS-HOST-UI/pull/1113
*  https://github.com/PAXTechnologyInc/BroadPOS-Host-Feature/pull/342
*  https://github.com/PAXTechnologyInc/BroadPOS-Host-POSLink-Bridge/pull/697

### How do you fix?  
 remove the -3 check
### Test Evidence

https://github.com/user-attachments/assets/ba929e9e-03cf-4645-ad7e-511b7da960c7


https://github.com/user-attachments/assets/b277d154-1564-4e9b-81fb-40b3ff5e5eb9

