### PR TITLE
[POSUI-318]With POSLinkUI Demo, on the tip page, user must tap the tip field first to be able to input tip using the physical keyboard

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/information/DisplayApproveMessageFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/information/DisplayApproveMessageFragment.java
@@ -13,6 +13,7 @@ import com.pax.us.pay.ui.constant.entry.InformationEntry;
 import com.paxus.pay.poslinkui.demo.R;
 import com.paxus.pay.poslinkui.demo.entry.BaseEntryFragment;
 import com.paxus.pay.poslinkui.demo.utils.Toast;
+import com.paxus.pay.poslinkui.demo.view.TextField;
 
 /**
  * Implement information entry action {@value InformationEntry#ACTION_DISPLAY_APPROVE_MESSAGE}
@@ -34,6 +35,11 @@ public class DisplayApproveMessageFragment extends BaseEntryFragment {
     @Override
     protected void loadView(View rootView) {
         new DisplayApprovalUtils().getApprovalStrategy(cardType).displayApproval(getContext(), (ConstraintLayout) rootView, cardType, () -> sendNext(null));
+    }
+
+    @Override
+    protected TextField[] focusableTextFields() {
+        return null;
     }
 
 }

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
@@ -132,6 +132,7 @@ public class TipFragment extends BaseEntryFragment {
         //Select and Enter Tip
         SelectOptionsView tipOptionsView = rootView.findViewById(R.id.select_view_tip_options);
         tipInputEditText = rootView.findViewById(R.id.edit_text_tip_entry);
+        tipInputEditText.requestFocus();
         if(isSelectTipEnabled){
             tipOptionsView.setVisibility(View.VISIBLE);
             tipOptionsView.initialize(getActivity(), tipOptionList.size(), tipOptionList, option -> {


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-318

### Related Pull Requests  
*

### Root Cause Analysis (RCA)


### How do you fix?  
enable text focus in TipFragment & fix compilation error in DisplayApproveMessageFragment.java

### Test Checklist (please check all that apply)
[x] Positive tests – does it work as expected with valid inputs?

[x] Negative tests – does it fail gracefully with invalid inputs or errors?

[x] Boundary tests – have edge cases been considered (e.g. empty, null, limits)?

[x] Regression tests – does it break any existing functionality?

### Test Evidence
test on A80(with physical keyboard) & A920MAX(without physical keyboard), with Tip Select Mode Enable & Disable cases, no regression found

https://github.com/user-attachments/assets/563a8d09-18c7-4c5f-8a87-22532f3a9312

