### PR TITLE
[POSUI-295] [Paragon] When sending the CLEARMESSAGE/RESET commands wi…

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/POSLinkStatusManager.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/POSLinkStatusManager.java
@@ -46,10 +46,10 @@ public class POSLinkStatusManager extends BroadcastReceiver implements Lifecycle
     @Override
     public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
         switch (event) {
-            case ON_START:
+            case ON_CREATE:
                 fragmentContext.registerReceiver(this, getIntentFilter());
                 break;
-            case ON_STOP:
+            case ON_DESTROY:
                 fragmentContext.unregisterReceiver(this);
                 break;
         }


### PR DESCRIPTION
…th POSLinkUI installed, POSLink Demo returns OK, but the app doesn't clear message on the screen and return to the idle screen

### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-295

### Related Pull Requests  
*

### RCA
when CLEAR_MESSAGE menu is clicked by POSLink Demo, POSLink UI Demo(ShowMessageFragment) is not in the foreground.
The behavior of RESET is as expected.

### How do you fix?  
Extend the receiver's lifecycle by moving the unregister call from onStop() to onDestroy() 

### Test Evidence

https://github.com/user-attachments/assets/c8c6bb88-7cae-4775-af1e-e471110e731e

