### PR TITLE
[POSUI-306] [POSLink UI Demo] The Invoice ID page does not display th…

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/numbertext/InvoiceNumberFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/numbertext/InvoiceNumberFragment.java
@@ -45,7 +45,7 @@ public class InvoiceNumberFragment extends ANumTextFragment {
             maxLength = ValuePatternUtils.getMaxLength(valuePatten);
         }
 
-        allText = InputType.ALLTEXT.equals(bundle.getString(EntryExtraData.PARAM_EINPUT_TYPE));
+        allText = InputType.ALLTEXT.equals(bundle.getString(EntryExtraData.PARAM_EINPUT_TYPE, InputType.ALLTEXT));
     }
 
     @Override


### PR DESCRIPTION
…e virtual letter keyboard; it should display the virtual alphanumeric keyboard similar to the default BroadPOS UI

### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-306

### Related Pull Requests  
*

### RCA
It is caused by DetectInvoiceAction did not send RPCAction with PARAM_EINPUT_TYPE param, which result in InvoiceNumberFragment determining input type as number wrongly.

### How do you fix?  
Add default value for PARAM_EINPUT_TYPE in InvoiceNumberFragment

### Test Evidence

https://github.com/user-attachments/assets/b6fa86ea-bb24-4261-81e9-b7fb79c8f2ae

