### PR TITLE
[POSUI-324] fix: Display image correctly on SHOWMESSAGE command

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/poslink/ShowMessageFragment.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -13,6 +14,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.bumptech.glide.Glide;
 import com.pax.us.pay.ui.constant.entry.EntryExtraData;
 import com.pax.us.pay.ui.constant.entry.PoslinkEntry;
 import com.pax.us.pay.ui.constant.status.POSLinkStatus;
@@ -124,6 +126,26 @@ public class ShowMessageFragment extends BaseEntryFragment {
             totalLine.setText(total);
         }else {
             rootView.findViewById(R.id.total_layout).setVisibility(View.INVISIBLE);
+        }
+
+
+        ImageView msgImgView = rootView.findViewById(R.id.img_view_show_message);
+        LinearLayout llDescMsgLayout = rootView.findViewById(R.id.ll_desc_list_show_message);
+
+        if (!TextUtils.isEmpty(imgUrl)) {
+            msgImgView.setVisibility(View.VISIBLE);
+            Glide.with(this).load(imgUrl).into(msgImgView);
+            if (!TextUtils.isEmpty(imgDesc)) {
+                llDescMsgLayout.setVisibility(View.VISIBLE);
+                for (TextView textView: TextShowingUtils.getTitleViewList(requireContext(), title, lp, Color.WHITE, requireContext().getResources().getDimension(R.dimen.text_size_subtitle))) {
+                    titleLayout.addView(textView);
+                }
+            } else {
+                llDescMsgLayout.setVisibility(View.GONE);
+            }
+        } else {
+            llDescMsgLayout.setVisibility(View.GONE);
+            msgImgView.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/res/layout/fragment_show_message.xml
+++ b/app/src/main/res/layout/fragment_show_message.xml
@@ -14,13 +14,39 @@
         android:orientation="horizontal"
         android:layout_marginTop="10dp"
         android:layout_alignParentTop="true"/>
+
     <ListView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:id="@+id/list_view"
-        android:layout_above="@id/tax_layout"
         android:layout_below="@id/title_layout_show_message"
         android:layout_marginVertical="10dp"/>
+
+    <LinearLayout
+        android:id="@+id/ll_desc_msg_list_show_message"
+        android:layout_below="@id/list_view"
+        android:layout_above="@id/tax_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="5dp"
+        android:orientation="vertical"
+        android:paddingTop="5dp">
+
+        <ImageView
+            android:id="@+id/img_view_show_message"
+            android:layout_width="match_parent"
+            android:layout_height="150dp"
+            android:scaleType="fitXY"
+            android:visibility="gone" />
+
+        <LinearLayout
+            android:id="@+id/ll_desc_list_show_message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:orientation="horizontal"
+            android:visibility="gone" />
+    </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -42,6 +68,7 @@
             android:id="@+id/tax_line"
             android:textSize="@dimen/text_size_subtitle"/>
     </LinearLayout>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-324

### Related Pull Requests  
*

### How do you fix?  

Modify the code in the "BroadPOS-Host-POSLink-Bridge"  to grant FileProvider permissions for image files to ensure POSLinkUI-Demo can obtain temporary permissions, and add image display code to POSLinkUI-Demo.

### Test Evidence
With POSLinkUI-Demo:
https://github.com/user-attachments/assets/8cc5a623-53ae-4d75-9cb8-8be599ca88c1

BroadPOS-PaygistiX only:

https://github.com/user-attachments/assets/c05c99ca-6b85-4008-bd97-3e81f84f7158


