### PR TITLE
[POSUI-307] [Shift4 Lite] [Test] With POSLinkUI Demo installed, the t…

### DIFF
--- a/app/src/main/res/layout/fragment_show_text_box.xml
+++ b/app/src/main/res/layout/fragment_show_text_box.xml
@@ -30,7 +30,8 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:id="@+id/button_layout"
-        android:layout_margin="5dp">
+        android:layout_margin="5dp"
+        android:baselineAligned="false">
         <Button
             android:layout_width="0dp"
             android:layout_height="@dimen/button_height"


### PR DESCRIPTION
…hird Button in SHOWTEXTBOX Command is misaligned with other Buttons

### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-307

### Related Pull Requests  
*

### RCA  
By default, LinearLayout performs baseline alignment (android:baselineAligned="true").
When multiple child views contain text (such as Buttons), LinearLayout will try to align their text baselines rather than their tops or bottoms

### How do you fix?  
set baselineAligned to "false"

### Test Evidence
test with same text and long button name 


https://github.com/user-attachments/assets/6656da78-65ea-4e1c-8a6e-696bbb02c27c


https://github.com/user-attachments/assets/791dfa12-44e0-4307-8d1e-305ddf933af2




