### PR TITLE
[POSUI-293] [POSUI-312] InputAccount prompt for small screen. Tip=0 vs Untipped case.

### DIFF
--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/CashbackFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/CashbackFragment.java
@@ -72,7 +72,7 @@ public class CashbackFragment extends BaseEntryFragment {
             }
         }
 
-        promptOther = bundle.getBoolean(EntryExtraData.PARAM_ENABLE_OTHER_PROMPT) | true;
+        promptOther = bundle.getBoolean(EntryExtraData.PARAM_ENABLE_OTHER_PROMPT, false);
     }
 
 

--- a/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
+++ b/app/src/main/java/com/paxus/pay/poslinkui/demo/entry/text/amount/TipFragment.java
@@ -54,6 +54,7 @@ public class TipFragment extends BaseEntryFragment {
     private TextField tipInputEditText;
 
     long tip = 0;
+    Boolean tipFieldModified;
 
     @Override
     protected int getLayoutResourceId() {
@@ -71,7 +72,7 @@ public class TipFragment extends BaseEntryFragment {
         }
         baseAmount = bundle.getLong(EntryExtraData.PARAM_BASE_AMOUNT, -1);
 
-        tipName = bundle.getString(EntryExtraData.PARAM_TIP_NAME);
+        tipName = bundle.getString(EntryExtraData.PARAM_TIP_NAME, getString(R.string.tip_name));
         String tipUnit = bundle.getString(EntryExtraData.PARAM_TIP_UNIT, UnitType.CENT);
 
         //Tip Summary
@@ -99,7 +100,7 @@ public class TipFragment extends BaseEntryFragment {
                 try{
                     tipAmount = Long.parseLong(tipOptions[i]) * (tipUnit.equals(UnitType.DOLLAR) ? 100 : 1);
                     tipRate = tipRateOptions[i];
-                } catch (NumberFormatException | IndexOutOfBoundsException e){
+                } catch (NumberFormatException | IndexOutOfBoundsException ignored){
                 }
                 tipOptionList.add(new SelectOptionsView.Option(null, CurrencyUtils.convert(tipAmount, currency), tipRate, tipAmount));
             }
@@ -167,10 +168,12 @@ public class TipFragment extends BaseEntryFragment {
             @Override public void afterTextChanged(Editable s) {
                 super.afterTextChanged(s);
                 tip = CurrencyUtils.parse(s.toString());
+                tipFieldModified = true;
             }
         });
         tipInputEditText.setText(String.valueOf(tip)); //Initialize TextWatcher with Default Tip Value
         tipInputEditText.setSelection(tipInputEditText.getEditableText().length());
+        tipFieldModified = false;
 
         //Confirm
         Button confirmButton = rootView.findViewById(R.id.button_confirm);
@@ -231,11 +234,13 @@ public class TipFragment extends BaseEntryFragment {
     private void submit(long value) {
         Bundle bundle = new Bundle();
 
-        if(value>=0) {
+        // If user intentionally decides not to tip (Press NoTip or enter 0), do not submit PARAM_TIP.
+        if( (value == -1L) || (value == 0L && tipFieldModified)) {
+            sendNext(bundle);
+        } else {
             bundle.putLong(EntryRequest.PARAM_TIP, value);
+            sendNext(bundle);
         }
-
-        sendNext(bundle);
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_input_account.xml
+++ b/app/src/main/res/layout/fragment_input_account.xml
@@ -117,7 +117,9 @@
         app:layout_constraintTop_toBottomOf="@id/divider1"
         app:layout_constraintBottom_toTopOf="@id/edit_account"
 
-        tools:text="Enter Card Number"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        tools:text="Please Enter Card Number, Longer Prompt for Test"
         tools:textColor="@color/black"
         />
 
@@ -167,7 +169,7 @@
     <LinearLayout
         android:id="@+id/entry_mode_view"
         android:layout_width="match_parent"
-        android:layout_height="200dp"
+        android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:weightSum="3"
         android:layout_marginTop="8dp"


### PR DESCRIPTION
### JIRA Ticket  
https://pax-us.atlassian.net/browse/POSUI-293
https://pax-us.atlassian.net/browse/POSUI-312

### Related Pull Requests  


### How do you fix?  


### Test Evidence
**POSUI-293**
<img width="1448" height="1474" alt="image" src="https://github.com/user-attachments/assets/58c5cf85-5fc6-4d62-ad0b-1594cfdbf7f6" />

**POSUI-312**
https://github.com/user-attachments/assets/4e78312c-4372-4bbc-97a3-ee0109dcb15a

Transaction 1: 
Press NoTip -> NO param_tip -> Tip = 0

Transaction 2:
Confirm without setting anything -> param_tip = 0L -> Untipped

Transaction 3:
Confirm by setting 0 -> NO param_tip -> Tip = 0

Transaction 4 (First try failed in attached video):
Confirm by setting 0.04 -> param_tip = 4L -> Tip = 0.04
